### PR TITLE
Uart: fix acknowledge of UART errors

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -30,8 +30,8 @@ SERCOM::SERCOM(Sercom* s)
 */
 void SERCOM::initUART(SercomUartMode mode, SercomUartSampleRate sampleRate, uint32_t baudrate)
 {
-  resetUART();
   initClockNVIC();
+  resetUART();
 
   //Setting the CTRLA register
   sercom->USART.CTRLA.reg =	SERCOM_USART_CTRLA_MODE(mode) |
@@ -125,6 +125,16 @@ bool SERCOM::availableDataUART()
 {
   //RXC : Receive Complete
   return sercom->USART.INTFLAG.bit.RXC;
+}
+
+bool SERCOM::isUARTError()
+{
+  return sercom->USART.INTFLAG.bit.ERROR;
+}
+
+void SERCOM::acknowledgeUARTError()
+{
+  sercom->USART.INTFLAG.bit.ERROR = 1;
 }
 
 bool SERCOM::isBufferOverflowErrorUART()

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -162,6 +162,8 @@ class SERCOM
 		bool isDataRegisterEmptyUART( void ) ;
 		uint8_t readDataUART( void ) ;
 		int writeDataUART(uint8_t data) ;
+		bool isUARTError() ;
+		void acknowledgeUARTError() ;
 
 		/* ========== SPI ========== */
 		void initSPI(SercomSpiTXPad mosi, SercomRXPad miso, SercomSpiCharSize charSize, SercomDataOrder dataOrder) ;

--- a/cores/arduino/Uart.cpp
+++ b/cores/arduino/Uart.cpp
@@ -59,15 +59,15 @@ void Uart::flush()
 
 void Uart::IrqHandler()
 {
-  if(sercom->availableDataUART())
-  {
+  if (sercom->availableDataUART()) {
     rxBuffer.store_char(sercom->readDataUART());
   }
 
-  if(  sercom->isBufferOverflowErrorUART() ||
-    sercom->isFrameErrorUART() ||
-    sercom->isParityErrorUART())
-  {
+  if (sercom->isUARTError()) {
+    sercom->acknowledgeUARTError();
+    // TODO: if (sercom->isBufferOverflowErrorUART()) ....
+    // TODO: if (sercom->isFrameErrorUART()) ....
+    // TODO: if (sercom->isParityErrorUART()) ....
     sercom->clearStatusUART();
   }
 }


### PR DESCRIPTION
This fix lock-ups on UART errors.

Some examples where UART errors may happens:
- playing with wires (disconnecting and reconnecting RX/TX while the board is running)
- by calling Serial.begin when the connected device is already transmitting

