### PR TITLE
Fix for deadlock conditions after i2c bus errors

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -493,6 +493,12 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
   {
     while( !sercom->I2CM.INTFLAG.bit.SB )
     {
+        // If the slave NACKS the address, the MB bit will be set.
+        // In that case, send a stop condition and return false.
+        if (sercom->I2CM.INTFLAG.bit.MB) {
+            sercom->I2CM.CTRLB.bit.CMD = 3; // Stop condition
+            return false;
+        }
       // Wait transmission complete
     }
 
@@ -518,7 +524,14 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
   sercom->I2CM.DATA.bit.DATA = data;
 
   //Wait transmission successful
-  while(!sercom->I2CM.INTFLAG.bit.MB);
+  while(!sercom->I2CM.INTFLAG.bit.MB) {
+
+    // If a bus error occurs, the MB bit may never be set.
+    // Check the bus error bit and bail if it's set.
+    if (sercom->I2CM.STATUS.bit.BUSERR) {
+      return false;
+    }
+  }
 
   //Problems on line? nack received?
   if(sercom->I2CM.STATUS.bit.RXNACK)


### PR DESCRIPTION
Hello. I'm working on getting my project, Modulo (www.modulo.co) working with the Arduino Zero. Modulo uses hot plugging of i2c devices, so it tends to stress test handling of i2c bus errors. I found two places in SERCOM.cpp where incorrect handling of error conditions can cause a deadlock to occur. This pull request includes simple fixes for both of them.

The first occurs when an addressed device simply doesn't respond. This can be easily reproduced by doing a Wire.requestFrom() to an address that doesn't exist. Without the fix the arduino will completely lock up. With the fix, requestFrom returns an error. The bug is that it waits until the SB (slave on bus) bit is set in the INTFLAGS register, but when a nack occurs that never happens so we're stuck in an infinite loop. The fix is to also look for the MB flag to be set. If it is, issue a stop condition and return.

The second happens when a bus error (ie, an illegal stop condition) occurs while sending data as a master. This can be reproduced by connecting/disconnecting the SDA and SCL lines while i2c communication is in progress. In that case we are waiting for the MB (master on bus) flag to be set. When a bus error occurs that never happens, so again we end up in an infinite loop. The fix here is to also look for the BUSERR flag to be set. If it is, return an error condition.

Please let me know if there's any additional information I can provide on the problems or the fixes. Thanks.