### PR TITLE
Add Sercom defs for SPI and Wire in variant

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -204,6 +204,21 @@ void SPIClass::detachInterrupt() {
 
 #if SPI_INTERFACES_COUNT > 0
 
+/* In case new variant doesn't define these macros,
+ * we put here the ones for Arduino Zero.
+ *
+ * These values should be different on some variants!
+ *
+ * The SPI PAD values can be found in cores/arduino/SERCOM.h:
+ *   - SercomSpiTXPad
+ *   - SercomRXPad
+ */
+#ifndef PERIPH_SPI
+#define PERIPH_SPI           sercom4
+#define PAD_SPI_TX           SPI_PAD_2_SCK_3
+#define PAD_SPI_RX           SERCOM_RX_PAD_0
+#endif // PERIPH_SPI
+
 SPIClass SPI( &PERIPH_SPI, PIN_SPI_MISO, PIN_SPI_SCK, PIN_SPI_MOSI, PAD_SPI_TX, PAD_SPI_RX );
 
 #endif // SPI_INTERFACES_COUNT > 0

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -28,15 +28,20 @@
 
 const SPISettings DEFAULT_SPI_SETTINGS = SPISettings();
 
-SPIClass::SPIClass(SERCOM *p_sercom, uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI)
+SPIClass::SPIClass(SERCOM *p_sercom, uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI, SercomSpiTXPad PadTx, SercomRXPad PadRx)
 {
   initialized = false;
   assert(p_sercom != NULL);
   _p_sercom = p_sercom;
 
+  // pins
   _uc_pinMiso = uc_pinMISO;
   _uc_pinSCK = uc_pinSCK;
   _uc_pinMosi = uc_pinMOSI;
+
+  // SERCOM pads
+  _padTx=PadTx;
+  _padRx=PadRx;
 }
 
 void SPIClass::begin()
@@ -65,7 +70,7 @@ void SPIClass::config(SPISettings settings)
 {
   _p_sercom->disableSPI();
 
-  _p_sercom->initSPI(SPI_PAD_2_SCK_3, SERCOM_RX_PAD_0, SPI_CHAR_SIZE_8_BITS, settings.bitOrder);
+  _p_sercom->initSPI(_padTx, _padRx, SPI_CHAR_SIZE_8_BITS, settings.bitOrder);
   _p_sercom->initSPIClock(settings.dataMode, settings.clockFreq);
 
   _p_sercom->enableSPI();
@@ -197,4 +202,8 @@ void SPIClass::detachInterrupt() {
   // Should be disableInterrupt()
 }
 
-SPIClass SPI( &sercom4, PIN_SPI_MISO, PIN_SPI_SCK, PIN_SPI_MOSI );
+#if SPI_INTERFACES_COUNT > 0
+
+SPIClass SPI( &PERIPH_SPI, PIN_SPI_MISO, PIN_SPI_SCK, PIN_SPI_MOSI, PAD_SPI_TX, PAD_SPI_RX );
+
+#endif // SPI_INTERFACES_COUNT > 0

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -91,7 +91,8 @@ class SPISettings {
 
 class SPIClass {
   public:
-  SPIClass(SERCOM *p_sercom, uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI);
+  SPIClass(SERCOM *p_sercom, uint8_t uc_pinMISO, uint8_t uc_pinSCK, uint8_t uc_pinMOSI, SercomSpiTXPad, SercomRXPad);
+
 
   byte transfer(uint8_t data);
   inline void transfer(void *buf, size_t count);
@@ -120,6 +121,10 @@ class SPIClass {
   uint8_t _uc_pinMiso;
   uint8_t _uc_pinMosi;
   uint8_t _uc_pinSCK;
+
+  SercomSpiTXPad _padTx;
+  SercomRXPad _padRx;
+
   bool initialized;
   uint8_t interruptMode;
   char interruptSave;

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -1,0 +1,8 @@
+name=SPI
+version=1.0
+author=Jonathan BAUDIN, Thibaut VIARD, Arduino
+maintainer=Arduino <info@arduino.cc>
+sentence=Enables the communication with devices that use the Serial Peripheral Interface (SPI) Bus. Specific implementation for Arduino Zero.
+paragraph=
+url=http://www.arduino.cc/en/Reference/SPI
+architectures=samd

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -257,25 +257,17 @@ void TwoWire::onService(void)
 }
 
 #if WIRE_INTERFACES_COUNT > 0
-/*static void Wire_Init(void) {
-  pmc_enable_periph_clk(WIRE_INTERFACE_ID);
-  PIO_Configure(
-      g_APinDescription[PIN_WIRE_SDA].pPort,
-      g_APinDescription[PIN_WIRE_SDA].ulPinType,
-      g_APinDescription[PIN_WIRE_SDA].ulPin,
-      g_APinDescription[PIN_WIRE_SDA].ulPinConfiguration);
-  PIO_Configure(
-      g_APinDescription[PIN_WIRE_SCL].pPort,
-      g_APinDescription[PIN_WIRE_SCL].ulPinType,
-      g_APinDescription[PIN_WIRE_SCL].ulPin,
-      g_APinDescription[PIN_WIRE_SCL].ulPinConfiguration);
 
-  NVIC_DisableIRQ(WIRE_ISR_ID);
-  NVIC_ClearPendingIRQ(WIRE_ISR_ID);
-  NVIC_SetPriority(WIRE_ISR_ID, 0);
-  NVIC_EnableIRQ(WIRE_ISR_ID);
-}*/
+/* In case new variant doesn't define these macros,
+ * we put here the ones for Arduino Zero.
+ *
+ * These values should be different on some variants!
+ */
 
+#ifndef PERIPH_WIRE
+#  define PERIPH_WIRE          sercom3
+#  define WIRE_IT_HANDLER      SERCOM3_Handler
+#endif // PERIPH_WIRE
 
 TwoWire Wire(&PERIPH_WIRE, PIN_WIRE_SDA, PIN_WIRE_SCL);
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -31,7 +31,7 @@
 class TwoWire : public Stream
 {
   public:
-    TwoWire(SERCOM *s);
+    TwoWire(SERCOM *s, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);
     void setClock(uint32_t); // dummy function
@@ -59,6 +59,9 @@ class TwoWire : public Stream
 
   private:
     SERCOM * sercom;
+    uint8_t _uc_pinSDA;
+    uint8_t _uc_pinSCL;
+
     bool transmissionBegun;
 
     // RX Buffer

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,0 +1,9 @@
+name=Wire
+version=1.0
+author=Jonathan BAUDIN, Thibaut VIARD, Arduino
+maintainer=Arduino <info@arduino.cc>
+sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. Specific implementation for Arduino Zero.
+paragraph=
+url=http://www.arduino.cc/en/Reference/Wire
+architectures=samd
+

--- a/variants/arduino_zero/variant.h
+++ b/variants/arduino_zero/variant.h
@@ -129,6 +129,9 @@ static const uint8_t ATN = PIN_ATN;
 #define PIN_SPI_MISO         (22u)
 #define PIN_SPI_MOSI         (23u)
 #define PIN_SPI_SCK          (24u)
+#define PERIPH_SPI           sercom4
+#define PAD_SPI_TX           SPI_PAD_2_SCK_3
+#define PAD_SPI_RX           SERCOM_RX_PAD_0
 
 static const uint8_t SS	  = PIN_A2 ;	// SERCOM4 last PAD is present on A2 but HW SS isn't used. Set here only for reference.
 static const uint8_t MOSI = PIN_SPI_MOSI ;
@@ -142,6 +145,8 @@ static const uint8_t SCK  = PIN_SPI_SCK ;
 
 #define PIN_WIRE_SDA         (20u)
 #define PIN_WIRE_SCL         (21u)
+#define PERIPH_WIRE          sercom3
+#define WIRE_IT_HANDLER      SERCOM3_Handler
 
 /*
  * USB


### PR DESCRIPTION
This PR allows people working on their own SAMD21 based variant to use different Sercom for either SPI or Wire.

This PR solves the two concerns pointed in https://github.com/arduino/ArduinoCore-samd/issues/3

Contains 5 atomic commits.