### PR TITLE
Relax digitalWrite parameter check

### DIFF
--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -86,11 +86,8 @@ void digitalWrite( uint32_t ulPin, uint32_t ulVal )
       PORT->Group[g_APinDescription[ulPin].ulPort].OUTCLR.reg = (1ul << g_APinDescription[ulPin].ulPin) ;
     break ;
 
-    case HIGH:
-      PORT->Group[g_APinDescription[ulPin].ulPort].OUTSET.reg = (1ul << g_APinDescription[ulPin].ulPin) ;
-    break ;
-
     default:
+      PORT->Group[g_APinDescription[ulPin].ulPort].OUTSET.reg = (1ul << g_APinDescription[ulPin].ulPin) ;
     break ;
   }
 


### PR DESCRIPTION
calling digitalWrite with any value different from 0 will end in performing digitalWrite(HIGH)
(to make it compatible with existing implementations for other cores)