### PR TITLE
External Interrupt handling fix

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -25,16 +25,12 @@
 extern "C" {
 #endif
 
-static struct
-{
-  uint32_t _ulPin ;
-  voidFuncPtr _callback ;
-} callbacksInt[EXTERNAL_NUM_INTERRUPTS] ;
+static voidFuncPtr callbacksInt[EXTERNAL_NUM_INTERRUPTS];
 
 /* Configure I/O interrupt sources */
 static void __initialize()
 {
-  memset( callbacksInt, 0, sizeof( callbacksInt ) ) ;
+  memset(callbacksInt, 0, sizeof(callbacksInt));
 
   NVIC_DisableIRQ( EIC_IRQn ) ;
   NVIC_ClearPendingIRQ( EIC_IRQn ) ;
@@ -88,8 +84,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   pinPeripheral(pin, PIO_EXTINT);
 
   // Assign callback to interrupt
-  callbacksInt[digitalPinToInterrupt(pin)]._ulPin = pin;
-  callbacksInt[digitalPinToInterrupt(pin)]._callback = callback;
+  callbacksInt[digitalPinToInterrupt(pin)] = callback;
 
   // Look for right CONFIG register to be addressed
   if (digitalPinToInterrupt(pin) > EXTERNAL_INT_7) {
@@ -153,9 +148,8 @@ void EIC_Handler( void )
     if ( (EIC->INTFLAG.reg & ( 1 << ul ) ) != 0 )
     {
       // Call the callback function if assigned
-      if ( callbacksInt[ul]._callback != NULL )
-      {
-        callbacksInt[ul]._callback() ;
+      if (callbacksInt[ul]) {
+        callbacksInt[ul]();
       }
 
       // Clear the interrupt


### PR DESCRIPTION
- NMI Interrupts are now correctly ignored (no more hardcoded pin numbers)
- `callbacksInt` doesn't need to be a structure, changed to a simple array of function pointers.

This pull request together with https://github.com/arduino/ArduinoCore-samd/commit/0368e10eaa984b86f5cbe3f80efbd83c5f94bd4c fix issue #30.

/cc @aethaniel @facchinm @manitou48