### PR TITLE
Wire: allow scanning bus via beginTransmission - endTransmission

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -110,12 +110,6 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 {
   transmissionBegun = false ;
 
-  // Check if there are data to send
-  if ( txBuffer.available() == 0)
-  {
-    return 4 ;
-  }
-
   // Start I2C transmission
   if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG ) )
   {


### PR DESCRIPTION
Using 
```C
beginTransmission(); 
endTransmission() 
```

to scan the I2C bus for devices is a very common practice. 
The patch solves the case when no byte was sent, only the address to be acknowledged.
