### PR TITLE
Add function setClock on Wire library

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -49,12 +49,14 @@ void TwoWire::begin(uint8_t address) {
   sercom->enableWIRE();
 }
 
-void TwoWire::end() {
+void TwoWire::setClock(uint32_t baudrate) {
   sercom->disableWIRE();
+  sercom->initMasterWIRE(baudrate);
+  sercom->enableWIRE();
 }
 
-void TwoWire::setClock(uint32_t frequency) {
-	// dummy funtion
+void TwoWire::end() {
+  sercom->disableWIRE();
 }
 
 uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -38,7 +38,7 @@ class TwoWire : public Stream
     void begin();
     void begin(uint8_t);
     void end();
-    void setClock(uint32_t); // dummy function
+    void setClock(uint32_t);
 
     void beginTransmission(uint8_t);
     uint8_t endTransmission(bool stopBit);


### PR DESCRIPTION
This is a cleaned version of PR #21.
I removed the limitation to baudrate.