### PR TITLE
A fix for the SerialUSB buffer overflow bug.

### DIFF
--- a/cores/arduino/USB/samd21_device.c
+++ b/cores/arduino/USB/samd21_device.c
@@ -34,8 +34,8 @@ extern "C"{
 //#define TRACE_DEVICE(x)	x
 #define TRACE_DEVICE(x)
 
-__attribute__((__aligned__(4))) /*__attribute__((__section__(".bss_hram0")))*/ uint8_t udd_ep_out_cache_buffer[4][64];
-__attribute__((__aligned__(4))) /*__attribute__((__section__(".bss_hram0")))*/ uint8_t udd_ep_in_cache_buffer[4][128];
+__attribute__((__aligned__(4))) /*__attribute__((__section__(".bss_hram0")))*/ uint8_t udd_ep_out_cache_buffer[4][UDD_OUT_CACHE_SIZE];
+__attribute__((__aligned__(4))) /*__attribute__((__section__(".bss_hram0")))*/ uint8_t udd_ep_in_cache_buffer[4][UDD_IN_CACHE_SIZE];
 
 /**
  * USB SRAM data containing pipe descriptor table

--- a/cores/arduino/USB/samd21_device.h
+++ b/cores/arduino/USB/samd21_device.h
@@ -26,6 +26,9 @@ extern "C" {
 #define EP0				0
 #define EPX_SIZE		64// 64 for Full Speed, EPT size max is 1024
 
+#define UDD_OUT_CACHE_SIZE 64
+#define UDD_IN_CACHE_SIZE 128
+
 // Force device low speed mode
 #define udd_force_low_speed()               USB->DEVICE.CTRLB.reg &= ~USB_DEVICE_CTRLB_SPDCONF_Msk; USB->DEVICE.CTRLB.reg |= USB_DEVICE_CTRLB_SPDCONF_1_Val
 // Force full speed mode


### PR DESCRIPTION
Send the data in chunks based on the buffer size
instead of assuming that the whole send data
will fit into the buffer.

This is one possible fix for the issue raised here:
https://forum.arduino.cc/index.php?topic=340897.0