### PR TITLE
Wire Slave

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -410,14 +410,12 @@ void SERCOM::initSlaveWIRE( uint8_t ucAddress )
   // Set slave mode
   sercom->I2CS.CTRLA.bit.MODE = I2C_SLAVE_OPERATION ;
 
-  // Enable Quick Command
-  sercom->I2CM.CTRLB.bit.QCEN = 1 ;
-
   sercom->I2CS.ADDR.reg = SERCOM_I2CS_ADDR_ADDR( ucAddress & 0x7Ful ) | // 0x7F, select only 7 bits
                           SERCOM_I2CS_ADDR_ADDRMASK( 0x3FFul ) ;    // 0x3FF all bits set
 
   // Set the interrupt register
-  sercom->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_AMATCH | // Address Match
+  sercom->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_PREC |   // Stop
+                              SERCOM_I2CS_INTENSET_AMATCH | // Address Match
                               SERCOM_I2CS_INTENSET_DRDY ;   // Data Ready
 
   while ( sercom->I2CM.SYNCBUSY.bit.SYSOP != 0 )
@@ -450,23 +448,35 @@ void SERCOM::initMasterWIRE( uint32_t baudrate )
 
 void SERCOM::prepareNackBitWIRE( void )
 {
-  // Send a NACK
-  sercom->I2CM.CTRLB.bit.ACKACT = 1;
+  if(isMasterWIRE()) {
+    // Send a NACK
+    sercom->I2CM.CTRLB.bit.ACKACT = 1;
+  } else {
+    sercom->I2CS.CTRLB.bit.ACKACT = 1;
+  }
 }
 
 void SERCOM::prepareAckBitWIRE( void )
 {
-  // Send an ACK
-  sercom->I2CM.CTRLB.bit.ACKACT = 0;
+  if(isMasterWIRE()) {
+    // Send an ACK
+    sercom->I2CM.CTRLB.bit.ACKACT = 0;
+  } else {
+    sercom->I2CS.CTRLB.bit.ACKACT = 0;
+  }
 }
 
-void SERCOM::prepareCommandBitsWire(SercomMasterCommandWire cmd)
+void SERCOM::prepareCommandBitsWire(uint8_t cmd)
 {
-  sercom->I2CM.CTRLB.bit.CMD = cmd;
+  if(isMasterWIRE()) {
+    sercom->I2CM.CTRLB.bit.CMD = cmd;
 
-  while(sercom->I2CM.SYNCBUSY.bit.SYSOP)
-  {
-    // Waiting for synchronization
+    while(sercom->I2CM.SYNCBUSY.bit.SYSOP)
+    {
+      // Waiting for synchronization
+    }
+  } else {
+    sercom->I2CS.CTRLB.bit.CMD = cmd;
   }
 }
 

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -191,7 +191,7 @@ class SERCOM
     void disableWIRE( void );
     void prepareNackBitWIRE( void ) ;
     void prepareAckBitWIRE( void ) ;
-    void prepareCommandBitsWire(SercomMasterCommandWire cmd);
+    void prepareCommandBitsWire(uint8_t cmd);
 		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag) ;
 		bool sendDataMasterWIRE(uint8_t data) ;
 		bool sendDataSlaveWIRE(uint8_t data) ;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -219,13 +219,26 @@ void TwoWire::onService(void)
 {
   if ( sercom->isSlaveWIRE() )
   {
-    if(sercom->isAddressMatch())  //Address Match
+    if(sercom->isStopDetectedWIRE() || 
+        (sercom->isAddressMatch() && sercom->isRestartDetectedWIRE())) //Stop or Restart detected
     {
       sercom->prepareAckBitWIRE();
       sercom->prepareCommandBitsWire(0x03);
 
-      //Is a request ?
-      if(sercom->isMasterReadOperationWIRE())
+      //Calling onReceiveCallback, if exists
+      if(onReceiveCallback)
+      {
+        onReceiveCallback(available());
+      }
+      
+      rxBuffer.clear();
+    }
+    else if(sercom->isAddressMatch())  //Address Match
+    {
+      sercom->prepareAckBitWIRE();
+      sercom->prepareCommandBitsWire(0x03);
+
+      if(sercom->isMasterReadOperationWIRE()) //Is a request ?
       {
         //Calling onRequestCallback, if exists
         if(onRequestCallback)
@@ -246,19 +259,6 @@ void TwoWire::onService(void)
       }
 
       sercom->prepareCommandBitsWire(0x03);
-    }
-    else if(sercom->isStopDetectedWIRE() || sercom->isRestartDetectedWIRE()) //Stop or Restart detected
-    {
-      sercom->prepareAckBitWIRE();
-      sercom->prepareCommandBitsWire(0x03);
-
-      //Calling onReceiveCallback, if exists
-      if(onReceiveCallback)
-      {
-        onReceiveCallback(available());
-      }
-      
-      rxBuffer.clear();
     }
   }
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -220,7 +220,7 @@ void TwoWire::onService(void)
   if ( sercom->isSlaveWIRE() )
   {
     if(sercom->isStopDetectedWIRE() || 
-        (sercom->isAddressMatch() && sercom->isRestartDetectedWIRE())) //Stop or Restart detected
+        (sercom->isAddressMatch() && sercom->isRestartDetectedWIRE() && !sercom->isMasterReadOperationWIRE())) //Stop or Restart detected
     {
       sercom->prepareAckBitWIRE();
       sercom->prepareCommandBitsWire(0x03);
@@ -240,6 +240,10 @@ void TwoWire::onService(void)
 
       if(sercom->isMasterReadOperationWIRE()) //Is a request ?
       {
+        // wait for data ready flag,
+        // before calling request callback
+        while(!sercom->isDataReadyWIRE());
+
         //Calling onRequestCallback, if exists
         if(onRequestCallback)
         {


### PR DESCRIPTION
Some changes to get Wire slave working, including:
 * calling ``pinPeripheral`` in ``begin`` to setup SDA and SCL pins like the master ``begin``
 * enabling the stop condition interrupt (``SERCOM_I2CS_INTENSET_PREC``)
 * ACK'ing or NACK'ing in the ISR and sending the appropriate command bits to clear the flags

__Note:__ there is still an issue with repeated starts, the timeout is not working, so if a repeated start is received without a subsequent stop or another repeated start, the receive callback is not called currently.