### PR TITLE
Added missing begin() variant with 2nd argument for configuring seria…

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -68,6 +68,7 @@ class HardwareSerial : public Stream
 {
   public:
     virtual void begin(unsigned long);
+    virtual void begin(unsigned long baudrate, uint8_t config);
     virtual void end();
     virtual int available(void) = 0;
     virtual int peek(void) = 0;


### PR DESCRIPTION
…l port (parity etc..)

Code using the missing begin() variant compiles. But due to missing hardware on my side for testing, I could not test it in real life.