### PR TITLE
Correct Wire master repeated start behaviour

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -477,16 +477,11 @@ void SERCOM::prepareCommandBitsWire(SercomMasterCommandWire cmd)
 
 bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag)
 {
-	return startTransmissionWIRE(address, flag, false);
-}
-
-bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool repeatedStart)
-{
   // 7-bits address + 1-bits R/W
   address = (address << 0x1ul) | flag;
 
-  // Wait idle bus mode
-  while ( !repeatedStart && !isBusIdleWIRE());
+  // Wait idle or owner bus mode
+  while ( !isBusIdleWIRE() && !isBusOwnerWIRE() );
 
   // Send start and address
   sercom->I2CM.ADDR.bit.ADDR = address;
@@ -578,6 +573,11 @@ bool SERCOM::isSlaveWIRE( void )
 bool SERCOM::isBusIdleWIRE( void )
 {
   return sercom->I2CM.STATUS.bit.BUSSTATE == WIRE_IDLE_STATE;
+}
+
+bool SERCOM::isBusOwnerWIRE( void )
+{
+  return sercom->I2CM.STATUS.bit.BUSSTATE == WIRE_OWNER_STATE;
 }
 
 bool SERCOM::isDataReadyWIRE( void )

--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -477,11 +477,16 @@ void SERCOM::prepareCommandBitsWire(SercomMasterCommandWire cmd)
 
 bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag)
 {
+	return startTransmissionWIRE(address, flag, false);
+}
+
+bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool repeatedStart)
+{
   // 7-bits address + 1-bits R/W
   address = (address << 0x1ul) | flag;
 
   // Wait idle bus mode
-  while ( !isBusIdleWIRE() );
+  while ( !repeatedStart && !isBusIdleWIRE());
 
   // Send start and address
   sercom->I2CM.ADDR.bit.ADDR = address;

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -194,12 +194,12 @@ class SERCOM
     void prepareAckBitWIRE( void ) ;
     void prepareCommandBitsWire(SercomMasterCommandWire cmd);
 		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag) ;
-		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool repeatedStart) ;
 		bool sendDataMasterWIRE(uint8_t data) ;
 		bool sendDataSlaveWIRE(uint8_t data) ;
 		bool isMasterWIRE( void ) ;
 		bool isSlaveWIRE( void ) ;
 		bool isBusIdleWIRE( void ) ;
+		bool isBusOwnerWIRE( void ) ;
 		bool isDataReadyWIRE( void ) ;
 		bool isStopDetectedWIRE( void ) ;
 		bool isRestartDetectedWIRE( void ) ;

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -194,6 +194,7 @@ class SERCOM
     void prepareAckBitWIRE( void ) ;
     void prepareCommandBitsWire(SercomMasterCommandWire cmd);
 		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag) ;
+		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool repeatedStart) ;
 		bool sendDataMasterWIRE(uint8_t data) ;
 		bool sendDataSlaveWIRE(uint8_t data) ;
 		bool isMasterWIRE( void ) ;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -82,12 +82,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
     }
     sercom->prepareNackBitWIRE();                           // Prepare NACK to stop slave transmission
     //sercom->readDataWIRE();                               // Clear data register to send NACK
-	
-	repeatedStart = !stopBit;
-	if (stopBit)
-	{
-		sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
-	}
+
+    repeatedStart = !stopBit;
+    if (stopBit)
+    {
+      sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
+    }
   }
 
   return byteRead;
@@ -137,7 +137,7 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   repeatedStart = !stopBit;
   if (stopBit)
   {
-	  sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+    sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
   }   
 
   return 0;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -68,7 +68,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   size_t byteRead = 0;
 
-  if(sercom->startTransmissionWIRE(address, WIRE_READ_FLAG))
+  if(sercom->startTransmissionWIRE(address, WIRE_READ_FLAG, repeatedStart))
   {
     // Read first data
     rxBuffer.store_char(sercom->readDataWIRE());
@@ -82,7 +82,12 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
     }
     sercom->prepareNackBitWIRE();                           // Prepare NACK to stop slave transmission
     //sercom->readDataWIRE();                               // Clear data register to send NACK
-    sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
+	
+	repeatedStart = !stopBit;
+	if (stopBit)
+	{
+		sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
+	}
   }
 
   return byteRead;
@@ -112,7 +117,7 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   transmissionBegun = false ;
 
   // Start I2C transmission
-  if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG ) )
+  if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG, repeatedStart ) )
   {
     sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
     return 2 ;  // Address error
@@ -128,7 +133,12 @@ uint8_t TwoWire::endTransmission(bool stopBit)
       return 3 ;  // Nack or error
     }
   }
-  sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+  
+  repeatedStart = !stopBit;
+  if (stopBit)
+  {
+	  sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+  }   
 
   return 0;
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -68,7 +68,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   size_t byteRead = 0;
 
-  if(sercom->startTransmissionWIRE(address, WIRE_READ_FLAG, repeatedStart))
+  if(sercom->startTransmissionWIRE(address, WIRE_READ_FLAG))
   {
     // Read first data
     rxBuffer.store_char(sercom->readDataWIRE());
@@ -83,7 +83,6 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
     sercom->prepareNackBitWIRE();                           // Prepare NACK to stop slave transmission
     //sercom->readDataWIRE();                               // Clear data register to send NACK
 
-    repeatedStart = !stopBit;
     if (stopBit)
     {
       sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop
@@ -117,7 +116,7 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   transmissionBegun = false ;
 
   // Start I2C transmission
-  if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG, repeatedStart ) )
+  if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG ) )
   {
     sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
     return 2 ;  // Address error
@@ -134,7 +133,6 @@ uint8_t TwoWire::endTransmission(bool stopBit)
     }
   }
   
-  repeatedStart = !stopBit;
   if (stopBit)
   {
     sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -67,7 +67,6 @@ class TwoWire : public Stream
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
-    bool repeatedStart;
 
     // RX Buffer
     RingBuffer rxBuffer;

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -67,7 +67,8 @@ class TwoWire : public Stream
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
-
+	bool repeatedStart;
+	
     // RX Buffer
     RingBuffer rxBuffer;
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -67,8 +67,8 @@ class TwoWire : public Stream
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
-	bool repeatedStart;
-	
+    bool repeatedStart;
+
     // RX Buffer
     RingBuffer rxBuffer;
 


### PR DESCRIPTION
The ``stopBit`` argument in ``TwoWire::requestFrom`` and ``TwoWire::endTransmission`` was being ignored.

Based on @legomanww's patch https://github.com/legomanww/ArduinoCore-samd/commit/6747af02eb0e32a3845f9f85ff5043fb8a7b2ea8.

This resolves #37.