### PR TITLE
Fix USB transfer type identification

### DIFF
--- a/libraries/USBHost/examples/USB_desc/USB_desc.ino
+++ b/libraries/USBHost/examples/USB_desc/USB_desc.ino
@@ -340,6 +340,8 @@ void printHIDdescr( uint8_t* descr_ptr )
 /* function to print endpoint descriptor */
 void printepdescr( uint8_t* descr_ptr )
 {
+  uint8_t transfer_type;
+
  USB_ENDPOINT_DESCRIPTOR* ep_ptr = ( USB_ENDPOINT_DESCRIPTOR* )descr_ptr;
   printProgStr(End_Header_str);
   printProgStr(End_Address_str);
@@ -347,9 +349,10 @@ void printepdescr( uint8_t* descr_ptr )
   else printProgStr(PSTR("OUT\t\t"));
   print_hex( (ep_ptr->bEndpointAddress & 0xF), 8 );
   printProgStr(End_Attr_str);
-  if( 0x03 & ep_ptr->bmAttributes ) printProgStr(PSTR("INTERRUPT\t"));
-  else if( 0x02 & ep_ptr->bmAttributes ) printProgStr(PSTR("BULK\t"));
-  else if( 0x01 & ep_ptr->bmAttributes ) printProgStr(PSTR("ISO\t"));
+  transfer_type = ep_ptr->bmAttributes & bmUSB_TRANSFER_TYPE;
+  if( transfer_type == USB_TRANSFER_TYPE_INTERRUPT ) printProgStr(PSTR("INTERRUPT\t"));
+  else if( transfer_type == USB_TRANSFER_TYPE_BULK ) printProgStr(PSTR("BULK\t"));
+  else if( transfer_type == USB_TRANSFER_TYPE_ISOCHRONOUS ) printProgStr(PSTR("ISO\t"));
   print_hex( ep_ptr->bmAttributes, 8 );
   printProgStr(End_Pktsize_str);
   print_hex( ep_ptr->wMaxPacketSize, 16 );


### PR DESCRIPTION
Bulk endpoints were incorrectly shown as Interrupt.