### PR TITLE
Fixing potential xxxtoa() issue with newer ARM GCC toolchain

### DIFF
--- a/cores/arduino/itoa.c
+++ b/cores/arduino/itoa.c
@@ -17,7 +17,7 @@
 */
 
 #include "itoa.h"
-#include <string.h>
+#include <stddef.h> // For NULL
 
 #ifdef __cplusplus
 extern "C" {

--- a/cores/arduino/itoa.h
+++ b/cores/arduino/itoa.h
@@ -16,7 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#pragma once
+#ifndef _ARDUINO_ITOA_
+#define _ARDUINO_ITOA_
 
 #ifdef __cplusplus
 extern "C"{
@@ -33,3 +34,4 @@ extern char* ultoa( unsigned long value, char *string, int radix ) ;
 } // extern "C"
 #endif
 
+#endif // _ARDUINO_ITOA_


### PR DESCRIPTION
This patch fix potential issue coming with newlib integrated at least since ARM GCC 4.9 2015q2:

https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=commit;h=32c96ddd14acadc82e7fccf110367ec3c8320c85

Some tests have been done without breaking anything at the moment.
Only WString.cpp is using this API.

Signed-off-by: Thibaut VIARD <aethaniel@sam-geek.org>