### PR TITLE
add support for I2C repeated start, tested with MB85RC256V

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -485,17 +485,19 @@ void SERCOM::prepareCommandBitsWire(uint8_t cmd)
   }
 }
 
-bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag)
+bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool _repeatstart)
 {
   // 7-bits address + 1-bits R/W
   address = (address << 0x1ul) | flag;
 
-  // Wait idle bus mode
-  while ( !isBusIdleWIRE() );
+  // Wait idle bus mode (except repeated start)
+  if (! _repeatstart) {
+    while ( !isBusIdleWIRE() );
+  }
 
-  // Send start and address
+  // Send start and address, in repeated start mode this will kick off the repstart too!
   sercom->I2CM.ADDR.bit.ADDR = address;
-
+  
   // Address Transmitted
   if ( flag == WIRE_WRITE_FLAG ) // Write mode
   {

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -193,7 +193,7 @@ class SERCOM
     void prepareNackBitWIRE( void ) ;
     void prepareAckBitWIRE( void ) ;
     void prepareCommandBitsWire(uint8_t cmd);
-		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag) ;
+    bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag, bool rs = false);
 		bool sendDataMasterWIRE(uint8_t data) ;
 		bool sendDataSlaveWIRE(uint8_t data) ;
 		bool isMasterWIRE( void ) ;

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -60,13 +60,15 @@ class TwoWire : public Stream
     using Print::write;
 
     void onService(void);
-
   private:
     SERCOM * sercom;
+
     uint8_t _uc_pinSDA;
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
+
+    bool _repeatedstart;
 
     // RX Buffer
     RingBuffer rxBuffer;


### PR DESCRIPTION
repeated start on the atsamd21 is a little interesting, instead of telling the i2c master to send a REPEATED_START (which you would *think* is the thing to do) you should send **no** command. then, next time the ADDR is set, it will automatically do the repeated start for you.

See table 27-12 in datasheet:
***If CMD 0x1 is issued, a repeated start will be issued followed by the transmission of the current address in ADDR.ADDR. If another address is desired, ADDR.ADDR must be written instead of the CMD bits. This will trigger a repeated start followed by transmission of the new address.***