### PR TITLE
Use asynchronous fractional mode to configure UART

### DIFF
--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -86,9 +86,8 @@ typedef enum
 
 typedef enum
 {
-	SAMPLE_RATE_x16 = 0,	//Arithmetic
-	SAMPLE_RATE_x8 = 0x2,	//Arithmetic
-	SAMPLE_RATE_x3 = 0x3	//Arithmetic
+	SAMPLE_RATE_x16 = 0x1,	//Fractional
+	SAMPLE_RATE_x8 = 0x3,	//Fractional
 } SercomUartSampleRate;
 
 typedef enum


### PR DESCRIPTION
This is an alternative to https://github.com/TomKeddie/ArduinoCore-samd/commit/103ddee889529da6da1a5b16d466e3f99df7677e from #81 to fix #84.

It changes ```SERCOM::initUART``` to use asynchronous fractional mode to configure the UART.

Tested with OS X 10.11.1 with the following baud rates: 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000. (Note: baud rate of 300 still has issues).