### PR TITLE
Fixed attachInterrupt() for use during sleep

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -66,6 +66,9 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
     enabled = 1;
   }
 
+  // Enable wakeup capability on pin in case being used during sleep
+  EIC->WAKEUP.reg |= (1 << in);
+
   // Assign pin to EIC
   pinPeripheral(pin, PIO_EXTINT);
 
@@ -118,6 +121,9 @@ void detachInterrupt(uint32_t pin)
     return;
 
   EIC->INTENCLR.reg = EIC_INTENCLR_EXTINT(1 << in);
+  
+  // Disable wakeup capability on pin during sleep
+  EIC->WAKEUP.reg &= ~(1 << in);
 }
 
 /*


### PR DESCRIPTION
The current implementation of attachInterrupt() will not work on Arduino Zero during sleep (standby mode). By default, all the pins wake up capability during sleep is disabled (Section 20.8.9 Wake-Up Enable in SAMD21 datasheet). Code is tested on a Arduino Zero for pins 0 - 24 (except pin 4). Without these changes, the processor will not wake up if it depends solely on the pin state change as the only source of waking up.