### PR TITLE
[USB CDC] Only re-enable IRQ if PRIMASK was 0 before disabling IRQ

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -158,7 +158,9 @@ void Serial_::accept(void)
 	uint8_t buffer[CDC_SERIAL_BUFFER_SIZE];
 	uint32_t len = usb.recv(CDC_ENDPOINT_OUT, &buffer, CDC_SERIAL_BUFFER_SIZE);
 
-	noInterrupts();
+	uint8_t enableInterrupts = ((__get_PRIMASK() & 0x1) == 0);
+	__disable_irq();
+
 	ring_buffer *ringBuffer = &cdc_rx_buffer;
 	uint32_t i = ringBuffer->head;
 
@@ -175,7 +177,9 @@ void Serial_::accept(void)
 			ringBuffer->full = true;
 	}
 	ringBuffer->head = i;
-	interrupts();
+	if (enableInterrupts) {
+		__enable_irq();
+	}
 }
 
 int Serial_::available(void)


### PR DESCRIPTION
As discussed by @matthijskooijman in https://github.com/arduino/ArduinoCore-samd/pull/65#issuecomment-171951566:

> Also, it might be good to let accept() use the same conditional interrupts() call (in a separate commit, of course)?

Also, incorporated feedback from https://github.com/arduino/ArduinoCore-samd/pull/65#issuecomment-171697817

> To emphasize the non-portability (and reduce confusion for people reading the code), it might be better to even just use __disable_irq() and __enable_irq() directly?