### PR TITLE
Correct use of I2C slave address mask

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -409,7 +409,7 @@ void SERCOM::initSlaveWIRE( uint8_t ucAddress )
   sercom->I2CS.CTRLA.bit.MODE = I2C_SLAVE_OPERATION ;
 
   sercom->I2CS.ADDR.reg = SERCOM_I2CS_ADDR_ADDR( ucAddress & 0x7Ful ) | // 0x7F, select only 7 bits
-                          SERCOM_I2CS_ADDR_ADDRMASK( 0x3FFul ) ;    // 0x3FF all bits set
+                          SERCOM_I2CS_ADDR_ADDRMASK( 0x00ul ) ;         // 0x00, only match exact address
 
   // Set the interrupt register
   sercom->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_PREC |   // Stop


### PR DESCRIPTION
Resolves #93.

The I2C slave address mask should be set to 0 for exact match as described in section 24.6.3.1 of the SAMD21 data sheet, when Address mode of ```MASK``` (0x00) is used (table 27-8).

The current value of 0x3ff matches all addresses.