### PR TITLE
Clear RX buffer in TwoWire::requestFrom before reading

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -71,6 +71,8 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   size_t byteRead = 0;
 
+  rxBuffer.clear();
+
   if(sercom->startTransmissionWIRE(address, WIRE_READ_FLAG))
   {
     // Read first data


### PR DESCRIPTION
Changes ```TwoWire::requestFrom``` behaviour to match AVR Wire lib. behaviour as discussed in #91.