### PR TITLE
Added externs for additional Wire instances

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -107,5 +107,10 @@ class TwoWire : public Stream
 };
 
 extern TwoWire Wire;
+extern TwoWire Wire1;
+extern TwoWire Wire2;
+extern TwoWire Wire3;
+extern TwoWire Wire4;
+extern TwoWire Wire5;
 
 #endif

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -106,11 +106,23 @@ class TwoWire : public Stream
     //static const uint32_t XMIT_TIMEOUT = 100000;
 };
 
-extern TwoWire Wire;
-extern TwoWire Wire1;
-extern TwoWire Wire2;
-extern TwoWire Wire3;
-extern TwoWire Wire4;
-extern TwoWire Wire5;
+#if WIRE_INTERFACES_COUNT > 0
+  extern TwoWire Wire;
+#endif
+#if WIRE_INTERFACES_COUNT > 1
+  extern TwoWire Wire1;
+#endif
+#if WIRE_INTERFACES_COUNT > 2
+  extern TwoWire Wire2;
+#endif
+#if WIRE_INTERFACES_COUNT > 3
+  extern TwoWire Wire3;
+#endif
+#if WIRE_INTERFACES_COUNT > 4
+  extern TwoWire Wire4;
+#endif
+#if WIRE_INTERFACES_COUNT > 5
+  extern TwoWire Wire5;
+#endif
 
 #endif


### PR DESCRIPTION
When working with our SAMD21J18A variant, we implement three I2C interfaces, and I found that the extern declarations were missing when I tried to use Wire1 and Wire2. Added support here for all six potential I2C instances.