### PR TITLE
Enable digitalRead on output pins, only enable pull-up in digitalWrite if pin is not output

### DIFF
--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -88,7 +88,7 @@ void digitalWrite( uint32_t ulPin, uint32_t ulVal )
 
   if ( (PORT->Group[port].DIRSET.reg & pinMask) == 0 ) {
     // the pin is not an output, disable pull-up if val is LOW, otherwise enable pull-up
-    PORT->Group[port].PINCFG[pin].bit.PULLEN = (ulVal != LOW) ;
+    PORT->Group[port].PINCFG[pin].bit.PULLEN = ((ulVal == LOW) ? 0 : 1) ;
   }
 
   switch ( ulVal )

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -82,8 +82,10 @@ void digitalWrite( uint32_t ulPin, uint32_t ulVal )
     return ;
   }
 
-  // Enable pull-up resistor
-  PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].reg=(uint8_t)(PORT_PINCFG_PULLEN) ;
+  if ( (PORT->Group[g_APinDescription[ulPin].ulPort].DIRSET.reg & (1ul << g_APinDescription[ulPin].ulPin)) == 0 ) {
+    // the pin is not an output, disable pull-up if val is LOW, otherwise enable pull-up
+    PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].bit.PULLEN = (ulVal != LOW) ;
+  }
 
   switch ( ulVal )
   {

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -58,8 +58,10 @@ void pinMode( uint32_t ulPin, uint32_t ulMode )
     break ;
 
     case OUTPUT:
+      // enable input, to support reading back values
+      PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].bit.INEN = 1 ;
+
       // Set pin to output mode
-      PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].reg&=~(uint8_t)(PORT_PINCFG_INEN) ;
       PORT->Group[g_APinDescription[ulPin].ulPort].DIRSET.reg = (uint32_t)(1<<g_APinDescription[ulPin].ulPin) ;
     break ;
 

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -82,19 +82,23 @@ void digitalWrite( uint32_t ulPin, uint32_t ulVal )
     return ;
   }
 
-  if ( (PORT->Group[g_APinDescription[ulPin].ulPort].DIRSET.reg & (1ul << g_APinDescription[ulPin].ulPin)) == 0 ) {
+  EPortType port = g_APinDescription[ulPin].ulPort;
+  uint32_t pin = g_APinDescription[ulPin].ulPin;
+  uint32_t pinMask = (1ul << pin);
+
+  if ( (PORT->Group[port].DIRSET.reg & pinMask) == 0 ) {
     // the pin is not an output, disable pull-up if val is LOW, otherwise enable pull-up
-    PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].bit.PULLEN = (ulVal != LOW) ;
+    PORT->Group[port].PINCFG[pin].bit.PULLEN = (ulVal != LOW) ;
   }
 
   switch ( ulVal )
   {
     case LOW:
-      PORT->Group[g_APinDescription[ulPin].ulPort].OUTCLR.reg = (1ul << g_APinDescription[ulPin].ulPin) ;
+      PORT->Group[port].OUTCLR.reg = pinMask;
     break ;
 
     default:
-      PORT->Group[g_APinDescription[ulPin].ulPort].OUTSET.reg = (1ul << g_APinDescription[ulPin].ulPin) ;
+      PORT->Group[port].OUTSET.reg = pinMask;
     break ;
   }
 

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -61,6 +61,9 @@ void pinMode( uint32_t ulPin, uint32_t ulMode )
       // enable input, to support reading back values
       PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].bit.INEN = 1 ;
 
+      // disable pullups
+      PORT->Group[g_APinDescription[ulPin].ulPort].PINCFG[g_APinDescription[ulPin].ulPin].bit.PULLEN = 0 ;
+
       // Set pin to output mode
       PORT->Group[g_APinDescription[ulPin].ulPort].DIRSET.reg = (uint32_t)(1<<g_APinDescription[ulPin].ulPin) ;
     break ;


### PR DESCRIPTION
Resolves #56 and #94.

* ```pinMode```:
 * enable input mode of output pins, to support using ```digitalRead``` to read current value (maintains AVR behaviour).
 * disable pull-up on output mode
* ```digitalWrite```:
 * only enable pull-up if pin is not in output mode and ```HIGH``` is passed in, disable pull-up if ```LOW``` passed in. (This is similar to #41, but it did not set OUT which is needed to enable pull-up - as per table 22-1 in the SAMD21 datasheet).
 * simplify some duplicated code, by using local variables.

If this is merged #41 can be closed.