### PR TITLE
[USB Device] sendStringDescriptor fixes

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -90,18 +90,18 @@ bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint8_t maxlen)
 	if (maxlen < 2)
 		return false;
 
-	uint16_t buff[maxlen/2];
-	int l = 1;
+	uint8_t buffer[maxlen];
+	buffer[0] = 0x03;
+	buffer[1] = strlen(string) * 2 + 2;
 
-	maxlen -= 2;
-	while (*string && maxlen>0)
-	{
-		buff[l++] = (uint8_t)(*string++);
-		maxlen -= 2;
+	uint8_t i;
+	for (i = 2; i < maxlen && *string; i++) {
+		buffer[i++] = *string++;
+		if (i == maxlen) break;
+		buffer[i] = 0;
 	}
-	buff[0] = (3<<8) | (l*2);
 
-	return USBDevice.sendControl((uint8_t*)buff, l*2);
+	return USBDevice.sendControl(buffer, i);
 }
 
 bool _dry_run = false;

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -91,8 +91,8 @@ bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint8_t maxlen)
 		return false;
 
 	uint8_t buffer[maxlen];
-	buffer[0] = 0x03;
-	buffer[1] = strlen((const char*)string) * 2 + 2;
+	buffer[0] = strlen((const char*)string) * 2 + 2;
+	buffer[1] = 0x03;
 
 	uint8_t i;
 	for (i = 2; i < maxlen && *string; i++) {

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -92,7 +92,7 @@ bool USBDeviceClass::sendStringDescriptor(const uint8_t *string, uint8_t maxlen)
 
 	uint8_t buffer[maxlen];
 	buffer[0] = 0x03;
-	buffer[1] = strlen(string) * 2 + 2;
+	buffer[1] = strlen((const char*)string) * 2 + 2;
 
 	uint8_t i;
 	for (i = 2; i < maxlen && *string; i++) {


### PR DESCRIPTION
Based off @cmaglie's [usb-send-descriptor-fix branch](https://github.com/cmaglie/ArduinoCore-samd/tree/usb-send-descriptor-fix) with a few modifications.

Tested with OS X 10.11.3, I can now see "Arduino Zero" in the USB section of the OS X System Reporter app.

Alternative to #75.

@agdl would you be able to test this out on Windows and Linux?