### PR TITLE
[Bootloader] Check sketch vectors before waiting for double tap

### DIFF
--- a/bootloaders/zero/main.c
+++ b/bootloaders/zero/main.c
@@ -44,37 +44,6 @@ static void check_start_application(void)
 //  LED_init();
 //  LED_off();
 
-#if defined(BOOT_DOUBLE_TAP_ADDRESS)
-  #define DOUBLE_TAP_MAGIC 0x07738135
-  if (PM->RCAUSE.bit.POR)
-  {
-    /* On power-on initialize double-tap */
-    BOOT_DOUBLE_TAP_DATA = 0;
-  }
-  else
-  {
-    if (BOOT_DOUBLE_TAP_DATA == DOUBLE_TAP_MAGIC)
-    {
-      /* Second tap, stay in bootloader */
-      BOOT_DOUBLE_TAP_DATA = 0;
-      return;
-    }
-
-    /* First tap */
-    BOOT_DOUBLE_TAP_DATA = DOUBLE_TAP_MAGIC;
-
-    /* Wait 0.5sec to see if the user tap reset again.
-     * The loop value is based on SAMD21 default 1MHz clock @ reset.
-     */
-    for (uint32_t i=0; i<125000; i++) /* 500ms */
-      /* force compiler to not optimize this... */
-      __asm__ __volatile__("");
-
-    /* Timeout happened, continue boot... */
-    BOOT_DOUBLE_TAP_DATA = 0;
-  }
-#endif
-
 #if (!defined DEBUG) || ((defined DEBUG) && (DEBUG == 0))
 uint32_t* pulSketch_Start_Address;
 #endif
@@ -107,6 +76,37 @@ uint32_t* pulSketch_Start_Address;
     /* Stay in bootloader */
     return;
   }
+
+#if defined(BOOT_DOUBLE_TAP_ADDRESS)
+  #define DOUBLE_TAP_MAGIC 0x07738135
+  if (PM->RCAUSE.bit.POR)
+  {
+    /* On power-on initialize double-tap */
+    BOOT_DOUBLE_TAP_DATA = 0;
+  }
+  else
+  {
+    if (BOOT_DOUBLE_TAP_DATA == DOUBLE_TAP_MAGIC)
+    {
+      /* Second tap, stay in bootloader */
+      BOOT_DOUBLE_TAP_DATA = 0;
+      return;
+    }
+
+    /* First tap */
+    BOOT_DOUBLE_TAP_DATA = DOUBLE_TAP_MAGIC;
+
+    /* Wait 0.5sec to see if the user tap reset again.
+     * The loop value is based on SAMD21 default 1MHz clock @ reset.
+     */
+    for (uint32_t i=0; i<125000; i++) /* 500ms */
+      /* force compiler to not optimize this... */
+      __asm__ __volatile__("");
+
+    /* Timeout happened, continue boot... */
+    BOOT_DOUBLE_TAP_DATA = 0;
+  }
+#endif
 
 /*
 #if defined(BOOT_LOAD_PIN)


### PR DESCRIPTION
Speeds up booting by ~650ms when sketch erases application flash on CDC 1200bps touch reset.

Note: I haven't rebuilt the boot loader binaries, to avoid conflicts with #104. Once we merge (or cherry pick) both, we'll have to rebuilt both Arduino and Genuino boot loaders again.

cc/ @aethaniel 
