### PR TITLE
[Bootloader] Correct baud rate value for UART

### DIFF
--- a/bootloaders/zero/sam_ba_serial.c
+++ b/bootloaders/zero/sam_ba_serial.c
@@ -108,8 +108,8 @@ void serial_open(void)
     /* Wait for synchronization */
   }
 
-	/* Baud rate 115200 - clock 8MHz -> BAUD value-50436 */
-	uart_basic_init(BOOT_USART_MODULE, 50436, BOOT_USART_PAD_SETTINGS);
+	/* Baud rate 115200 - clock 48MHz -> BAUD value-63018 */
+	uart_basic_init(BOOT_USART_MODULE, 63018, BOOT_USART_PAD_SETTINGS);
 
 	//Initialize flag
 	b_sharp_received = false;


### PR DESCRIPTION
Baud rate of 115200 was not working as advertised in the bootloader readme. Might have not been updated when the clock source was changed in #47.

cc/ @aethaniel