### PR TITLE
Force link _printf_float in dtostrf

### DIFF
--- a/cores/arduino/avr/dtostrf.c
+++ b/cores/arduino/avr/dtostrf.c
@@ -20,6 +20,8 @@
 #include <stdio.h>
 
 char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
+  asm(".global _printf_float");
+
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);
   sprintf(sout, fmt, val);


### PR DESCRIPTION
Resolves #109.

```_printf_float``` will only get linked in when ```dtostrf``` is used.

Alternative is to add a ```-u _printf_float``` linker flag, but this will increase sketch size for all sketches even if float support for printf is not needed.
(https://github.com/32bitmicro/newlib-nano-1.0/blob/master/newlib/README.nano)