### PR TITLE
Make attachInterrupt work as documented

### DIFF
--- a/VARIANT_COMPLIANCE_CHANGELOG
+++ b/VARIANT_COMPLIANCE_CHANGELOG
@@ -1,0 +1,8 @@
+SAMD CORE 1.6.5
+
+* digitalPinToInterrupt #define moved to Arduino.h, variant.h must no longer define it
+
+SAMD CORE 1.6.3
+
+* Timer for pin PWM selected based on value of PIN_ATTR_TIMER_ALT or PIN_ATTR_TIMER, 
+  prior to this pin type was used

--- a/VARIANT_COMPLIANCE_CHANGELOG
+++ b/VARIANT_COMPLIANCE_CHANGELOG
@@ -1,4 +1,4 @@
-SAMD CORE 1.6.5
+SAMD CORE 1.6.6
 
 * digitalPinToInterrupt #define moved to Arduino.h, variant.h must no longer define it
 

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -114,7 +114,7 @@ void loop( void ) ;
 
 #define bit(b) (1UL << (b))
 
-#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605)
+#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10606)
 // Interrupts
 #define digitalPinToInterrupt(P)   ( P )
 #endif

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -116,7 +116,7 @@ void loop( void ) ;
 
 #if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605)
 // Interrupts
-#define digitalPinToInterrupt(P)   ( g_APinDescription[P].ulExtInt )
+#define digitalPinToInterrupt(P)   ( P )
 #endif
 
 // USB Device

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -114,6 +114,11 @@ void loop( void ) ;
 
 #define bit(b) (1UL << (b))
 
+#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605)
+// Interrupts
+#define digitalPinToInterrupt(P)   ( g_APinDescription[P].ulExtInt )
+#endif
+
 // USB Device
 #include "USB/USBDesc.h"
 #include "USB/USBCore.h"

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -57,7 +57,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   uint32_t config;
   uint32_t pos;
 
-  EExt_Interrupts in = digitalPinToInterrupt(pin);
+  EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
   if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI)
     return;
 
@@ -116,7 +116,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
  */
 void detachInterrupt(uint32_t pin)
 {
-  EExt_Interrupts in = digitalPinToInterrupt(pin);
+  EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
   if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI)
     return;
 

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -57,7 +57,11 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   uint32_t config;
   uint32_t pos;
 
+#if ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605
   EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
+#else
+  EExt_Interrupts in = digitalPinToInterrupt(pin);
+#endif
   if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI)
     return;
 
@@ -116,7 +120,11 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
  */
 void detachInterrupt(uint32_t pin)
 {
+#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605)
   EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
+#else
+  EExt_Interrupts in = digitalPinToInterrupt(pin);
+#endif 
   if (in == NOT_AN_INTERRUPT || in == EXTERNAL_INT_NMI)
     return;
 

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -57,7 +57,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   uint32_t config;
   uint32_t pos;
 
-#if ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605
+#if ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10606
   EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
 #else
   EExt_Interrupts in = digitalPinToInterrupt(pin);
@@ -120,7 +120,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
  */
 void detachInterrupt(uint32_t pin)
 {
-#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10605)
+#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10606)
   EExt_Interrupts in = g_APinDescription[pin].ulExtInt;
 #else
   EExt_Interrupts in = digitalPinToInterrupt(pin);

--- a/variants/arduino_zero/variant.h
+++ b/variants/arduino_zero/variant.h
@@ -19,8 +19,8 @@
 #ifndef _VARIANT_ARDUINO_ZERO_
 #define _VARIANT_ARDUINO_ZERO_
 
-// The definitions here needs a SAMD core >=1.6.5
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10605
+// The definitions here needs a SAMD core >=1.6.6
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10606
 
 /*----------------------------------------------------------------------------
  *        Definitions

--- a/variants/arduino_zero/variant.h
+++ b/variants/arduino_zero/variant.h
@@ -19,8 +19,8 @@
 #ifndef _VARIANT_ARDUINO_ZERO_
 #define _VARIANT_ARDUINO_ZERO_
 
-// The definitions here needs a SAMD core >=1.6.3
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10603
+// The definitions here needs a SAMD core >=1.6.5
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10605
 
 /*----------------------------------------------------------------------------
  *        Definitions
@@ -75,9 +75,6 @@ extern "C"
  * https://github.com/arduino/Arduino/issues/1833
  */
 // #define digitalPinToTimer(P)
-
-// Interrupts
-#define digitalPinToInterrupt(P)   ( P )
 
 // LEDs
 #define PIN_LED_13           (13u)

--- a/variants/arduino_zero/variant.h
+++ b/variants/arduino_zero/variant.h
@@ -77,7 +77,7 @@ extern "C"
 // #define digitalPinToTimer(P)
 
 // Interrupts
-#define digitalPinToInterrupt(P)   ( g_APinDescription[P].ulExtInt )
+#define digitalPinToInterrupt(P)   ( P )
 
 // LEDs
 #define PIN_LED_13           (13u)

--- a/variants/mkr1000/variant.h
+++ b/variants/mkr1000/variant.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-// The definitions here needs a SAMD core >=1.6.3
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10603
+// The definitions here needs a SAMD core >=1.6.6
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10606
 
 #include <WVariant.h>
 
@@ -51,7 +51,6 @@
 #define portInputRegister(port)  (&(port->IN.reg))
 #define portModeRegister(port)   (&(port->DIR.reg))
 #define digitalPinHasPWM(P)      (g_APinDescription[P].ulPWMChannel != NOT_ON_PWM || g_APinDescription[P].ulTCChannel != NOT_ON_TIMER)
-#define digitalPinToInterrupt(P) (g_APinDescription[P].ulExtInt)
 
 /*
  * digitalPinToTimer(..) is AVR-specific and is not defined for SAMD


### PR DESCRIPTION
From the [```attachInterrupt``` docs](https://www.arduino.cc/en/Reference/AttachInterrupt), the recommended usage is:

```arduino
attachInterrupt(digitalPinToInterrupt(pin), ISR, mode);
```

This currently does not work with the SAMD core because ```digitalPinToInterrupt ``` is used inside ```attachInterrupt```, so the pin number must be passed in.

This patch addresses this by changing ```digitalPinToInterrupt ``` to return the argument passed in. ```attachInterrupt``` and ```detachInterrupt``` will use ```g_APinDescription[pin].ulExtInt;``` to map the pin to interrupt number directly.

It also moves ```digitalPinToInterrupt``` inside ```Arduino.h``` (if ```ARDUINO_SAMD_VARIANT_COMPLIANCE``` is >= 1.6.5). Existing behaviour will be used in variants with older compliance levels.

I've also added a new change log for variant compliance changes.