### PR TITLE
Correct SerialUSB return value

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -262,7 +262,7 @@ size_t Serial_::write(const uint8_t *buffer, size_t size)
 	{
 		uint32_t r = usb.send(CDC_ENDPOINT_IN, buffer, size);
 
-		if (r == 0) {
+		if (r > 0) {
 			return r;
 		} else {
 			setWriteError();

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -605,6 +605,7 @@ uint8_t USBDeviceClass::armRecv(uint32_t ep)
 // Blocking Send of data to an endpoint
 uint32_t USBDeviceClass::send(uint32_t ep, const void *data, uint32_t len)
 {
+	uint32_t written = 0;
 	uint32_t length = 0;
 
 	if (!_usbConfiguration)
@@ -675,10 +676,11 @@ uint32_t USBDeviceClass::send(uint32_t ep, const void *data, uint32_t len)
 		while (!usbd.epBank1IsTransferComplete(ep)) {
 			;  // need fire exit.
 		}
+		written += length;
 		len -= length;
 		data = (char *)data + length;
 	}
-	return len;
+	return written;
 }
 
 uint32_t USBDeviceClass::armSend(uint32_t ep, const void* data, uint32_t len)


### PR DESCRIPTION
Resolves #138.

As mentioned in #138 `SerialUSB.write` would always return zero, this corrects the return value to return the number of bytes written.