### PR TITLE
Add USB send timeout (take 2)

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -205,28 +205,14 @@ void Serial_::flush(void)
 
 size_t Serial_::write(const uint8_t *buffer, size_t size)
 {
-	/* only try to send bytes if the high-level CDC connection itself
-	 is open (not just the pipe) - the OS should set lineState when the port
-	 is opened and clear lineState when the port is closed.
-	 bytes sent before the user opens the connection or after
-	 the connection is closed are lost - just like with a UART. */
+	uint32_t r = usb.send(CDC_ENDPOINT_IN, buffer, size);
 
-	// TODO - ZE - check behavior on different OSes and test what happens if an
-	// open connection isn't broken cleanly (cable is yanked out, host dies
-	// or locks up, or host virtual serial port hangs)
-	if (_usbLineInfo.lineState > 0)  // Problem with Windows(R)
-	{
-		uint32_t r = usb.send(CDC_ENDPOINT_IN, buffer, size);
-
-		if (r > 0) {
-			return r;
-		} else {
-			setWriteError();
-			return 0;
-		}
+	if (r > 0) {
+		return r;
+	} else {
+		setWriteError();
+		return 0;
 	}
-	setWriteError();
-	return 0;
 }
 
 size_t Serial_::write(uint8_t c) {

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -640,6 +640,7 @@ uint32_t USBDeviceClass::send(uint32_t ep, const void *data, uint32_t len)
 			uint32_t timeout = microsecondsToClockCycles(TX_TIMEOUT_MS * 1000) / 23;
 
 			// Wait for (previous) transfer to complete
+			// inspired by Paul Stoffregen's work on Teensy
 			while (!usbd.epBank1IsTransferComplete(ep)) {
 				if (LastTransmitTimedOut[ep] || timeout-- == 0) {
 					LastTransmitTimedOut[ep] = 1;


### PR DESCRIPTION
Replacement for #152.

This time I've used Paul Stoffregen's work on Teensy as inspiration.

The initial send timeout is 70ms, however if a send times out the next one will fail immediately if the previous write is not complete. A ZLP will be attempted to send if a timeout occurs, to detect the endpoint is ready to receive.

I've also removed the check for line state in `Serial_::write`. After opening the port the user or application can manually disable DTR or RTS.