### PR TITLE
Increase buffer size for converting floats + doubles to String's

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -19,6 +19,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <float.h>
+
 #include "WString.h"
 #include "itoa.h"
 #include "avr/dtostrf.h"
@@ -110,14 +112,14 @@ String::String(unsigned long value, unsigned char base)
 String::String(float value, unsigned char decimalPlaces)
 {
 	init();
-	char buf[33];
+	char buf[FLT_MAX_10_EXP + 4 + decimalPlaces]; // +4, one for: 10, -, ., \0
 	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 
 String::String(double value, unsigned char decimalPlaces)
 {
 	init();
-	char buf[33];
+	char buf[DBL_MAX_10_EXP + 4 + decimalPlaces]; // +4, one for: 10, -, ., \0
 	*this = dtostrf(value, (decimalPlaces + 2), decimalPlaces, buf);
 }
 


### PR DESCRIPTION
Previously it was too small to print FLT_MAX and DBL_MAX.

Troublesome sketch:

``` arduino
#include <float.h> 

void setup() {
  Serial.begin(9600);
  while (!Serial);

  Serial.println(String(FLT_MAX));
  Serial.println(String(DBL_MAX));
  Serial.println(String(-FLT_MAX));
  Serial.println(String(-DBL_MAX));
}

void loop() {
}
```
