### PR TITLE
Add version to openocd tool path

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -125,7 +125,7 @@ tools.bossac_remote.upload.pattern=/usr/bin/run-bossac {upload.verbose} --port=t
 # OpenOCD sketch upload
 #
 
-tools.openocd.path={runtime.tools.openocd.path}
+tools.openocd.path={runtime.tools.openocd-0.9.0-arduino.path}
 tools.openocd.cmd=bin/openocd
 tools.openocd.cmd.windows=bin/openocd.exe
 


### PR DESCRIPTION
I was getting some conflicts with the openocd version used it in v1.0.7 of the 101 core.

cc/ @facchinm @cmaglie