### PR TITLE
Fixed issue where pins were not being configured properly in analogWr…

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -218,23 +218,23 @@ void analogWrite(uint32_t pin, uint32_t value)
     uint8_t tcChannel = GetTCChannelNumber(pinDesc.ulPWMChannel);
     static bool tcEnabled[TCC_INST_NUM+TC_INST_NUM];
 
+    if (attr & PIN_ATTR_TIMER) {
+      #if !(ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10603)
+      // Compatibility for cores based on SAMD core <=1.6.2
+      if (pinDesc.ulPinType == PIO_TIMER_ALT) {
+        pinPeripheral(pin, PIO_TIMER_ALT);
+      } else
+      #endif
+      {
+        pinPeripheral(pin, PIO_TIMER);
+      }
+    } else {
+      // We suppose that attr has PIN_ATTR_TIMER_ALT bit set...
+      pinPeripheral(pin, PIO_TIMER_ALT);
+    }
+
     if (!tcEnabled[tcNum]) {
       tcEnabled[tcNum] = true;
-
-      if (attr & PIN_ATTR_TIMER) {
-        #if !(ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10603)
-        // Compatibility for cores based on SAMD core <=1.6.2
-        if (pinDesc.ulPinType == PIO_TIMER_ALT) {
-          pinPeripheral(pin, PIO_TIMER_ALT);
-        } else
-        #endif
-        {
-          pinPeripheral(pin, PIO_TIMER);
-        }
-      } else {
-        // We suppose that attr has PIN_ATTR_TIMER_ALT bit set...
-        pinPeripheral(pin, PIO_TIMER_ALT);
-      }
 
       uint16_t GCLK_CLKCTRL_IDs[] = {
         GCLK_CLKCTRL_ID(GCM_TCC0_TCC1), // TCC0


### PR DESCRIPTION
…ite when multiple channels of the same TCC/TC module were being used to drive outputs.

The recent release of 1.6.7 introduced a bug that prevented pins from being configured properly in PWM mode.  This patch just rearranged a small bit of code to make sure that this doesn't occur.

The original commit where the bug was created was a few months back.  I posted a little more info over on that commit:
https://github.com/arduino/ArduinoCore-samd/commit/f221d1f1bdb3bfd87ca3f20520f67bef9450619e#diff-63b7293bbdf8f8f0f8b98336a5e85d83

