### PR TITLE
Fix regression: SerialUSB.available() do not return correct values

### DIFF
--- a/cores/arduino/USB/SAMD21_USBDevice.h
+++ b/cores/arduino/USB/SAMD21_USBDevice.h
@@ -350,7 +350,19 @@ public:
 
 	// Returns how many bytes are stored in the buffers
 	virtual uint32_t available() const {
-		return (last0 - first0) + (last1 - first1);
+		if (current == 0) {
+			bool ready = false;
+			synchronized {
+				ready = ready0;
+			}
+			return ready ? (last0 - first0) : 0;
+		} else {
+			bool ready = false;
+			synchronized {
+				ready = ready1;
+			}
+			return ready ? (last1 - first1) : 0;
+		}
 	}
 
 	void release() {


### PR DESCRIPTION
/cc @tbowmo

Fix #172 
