### PR TITLE
Launch libc initialization after hardware setup

### DIFF
--- a/cores/arduino/cortex_handlers.c
+++ b/cores/arduino/cortex_handlers.c
@@ -134,7 +134,6 @@ __attribute__ ((section(".isr_vector"))) const DeviceVectors exception_table =
 };
 
 extern int main(void);
-extern void __libc_init_array(void);
 
 /* This is called on processor reset to initialize the device and call main() */
 void Reset_Handler(void)
@@ -155,9 +154,6 @@ void Reset_Handler(void)
     for (pDest = &__bss_start__; pDest < &__bss_end__; pDest++)
       *pDest = 0;
   }
-
-  /* Initialize the C library */
-  __libc_init_array();
 
   SystemInit();
 

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -24,12 +24,17 @@
 void initVariant() __attribute__((weak));
 void initVariant() { }
 
+// Initialize C library
+extern "C" void __libc_init_array(void);
+
 /*
  * \brief Main entry point of Arduino application
  */
 int main( void )
 {
   init();
+
+  __libc_init_array();
 
   initVariant();
 


### PR DESCRIPTION
This pachs allows C++ global constructors to run after hardware initialization. This helps some libraries that setups hardware in class constructor to work properly.

See also #169

/cc @totalgee