### PR TITLE
Optimize SPI transfers

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -300,24 +300,11 @@ void SERCOM::setClockModeSPI(SercomSpiClockMode clockMode)
   enableSPI();
 }
 
-void SERCOM::writeDataSPI(uint8_t data)
+uint8_t SERCOM::transferDataSPI(uint8_t data)
 {
-  while( sercom->SPI.INTFLAG.bit.DRE == 0 )
-  {
-    // Waiting Data Registry Empty
-  }
-
   sercom->SPI.DATA.bit.DATA = data; // Writing data into Data register
 
-  while( sercom->SPI.INTFLAG.bit.TXC == 0 || sercom->SPI.INTFLAG.bit.DRE == 0 )
-  {
-    // Waiting Complete Transmission
-  }
-}
-
-uint16_t SERCOM::readDataSPI()
-{
-  while( sercom->SPI.INTFLAG.bit.DRE == 0 || sercom->SPI.INTFLAG.bit.RXC == 0 )
+  while( sercom->SPI.INTFLAG.bit.RXC == 0 )
   {
     // Waiting Complete Reception
   }

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -175,8 +175,7 @@ class SERCOM
 		SercomDataOrder getDataOrderSPI( void ) ;
 		void setBaudrateSPI(uint8_t divider) ;
 		void setClockModeSPI(SercomSpiClockMode clockMode) ;
-		void writeDataSPI(uint8_t data) ;
-		uint16_t readDataSPI( void ) ;
+		uint8_t transferDataSPI(uint8_t data) ;
 		bool isBufferOverflowErrorSPI( void ) ;
 		bool isDataRegisterEmptySPI( void ) ;
 		bool isTransmitCompleteSPI( void ) ;

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -187,11 +187,7 @@ void SPIClass::setClockDivider(uint8_t div)
 
 byte SPIClass::transfer(uint8_t data)
 {
-  // Writing the data
-  _p_sercom->writeDataSPI(data);
-
-  // Read data
-  return _p_sercom->readDataSPI() & 0xFF;
+  return _p_sercom->transferDataSPI(data);
 }
 
 uint16_t SPIClass::transfer16(uint16_t data) {
@@ -208,6 +204,15 @@ uint16_t SPIClass::transfer16(uint16_t data) {
   }
 
   return t.val;
+}
+
+void SPIClass::transfer(void *buf, size_t count)
+{
+  uint8_t *buffer = reinterpret_cast<uint8_t *>(buf);
+  for (size_t i=0; i<count; i++) {
+    *buffer = transfer(*buffer);
+    buffer++;
+  }
 }
 
 void SPIClass::attachInterrupt() {

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -96,7 +96,7 @@ class SPIClass {
 
   byte transfer(uint8_t data);
   uint16_t transfer16(uint16_t data);
-  inline void transfer(void *buf, size_t count);
+  void transfer(void *buf, size_t count);
 
   // Transaction Functions
   void usingInterrupt(int interruptNumber);
@@ -131,14 +131,6 @@ class SPIClass {
   char interruptSave;
   uint32_t interruptMask;
 };
-
-void SPIClass::transfer(void *buf, size_t count)
-{
-  // TODO: Optimize for faster block-transfer
-  uint8_t *buffer = reinterpret_cast<uint8_t *>(buf);
-  for (size_t i=0; i<count; i++)
-    buffer[i] = transfer(buffer[i]);
-}
 
 #if SPI_INTERFACES_COUNT > 0
   extern SPIClass SPI;


### PR DESCRIPTION
Combines `SERCOM::writeDataSPI` and `SERCOM::readDataSPI()` into a single `SERCOM::transferDataSPI` method and remove some flags checks.

Needs more testing, so far basic tests with WiFi101 and SD libraries seem ok.

cc/ @cmaglie @agdl