### PR TITLE
Add support for different bootloader sizes

### DIFF
--- a/cores/arduino/Reset.cpp
+++ b/cores/arduino/Reset.cpp
@@ -24,7 +24,9 @@ extern "C" {
 #endif
 
 #define NVM_MEMORY ((volatile uint16_t *)0x000000)
-#define APP_START 0x00002004
+#ifndef APP_START
+# define APP_START 0x00002004
+#endif
 
 static inline bool nvmReady(void) {
         return NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY;


### PR DESCRIPTION
Currently the bootloader size is hard coded to 8k, because APP_START is not modifiable.
Can we change this?