### PR TITLE
Add method to automatically retrieve sketch start

### DIFF
--- a/VARIANT_COMPLIANCE_CHANGELOG
+++ b/VARIANT_COMPLIANCE_CHANGELOG
@@ -1,3 +1,7 @@
+SAMD CORE 1.6.10
+
+* the linker script is use should define __text_start__ symbol at the beginning of .text section
+
 SAMD CORE 1.6.6
 
 * digitalPinToInterrupt #define moved to Arduino.h, variant.h must no longer define it

--- a/cores/arduino/Reset.cpp
+++ b/cores/arduino/Reset.cpp
@@ -24,7 +24,15 @@ extern "C" {
 #endif
 
 #define NVM_MEMORY ((volatile uint16_t *)0x000000)
+
+#if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10610)
+
+extern const uint32_t __text_start__;
+#define APP_START ((volatile uint32_t)(&__text_start__) + 4)
+
+#else
 #define APP_START 0x00002004
+#endif
 
 static inline bool nvmReady(void) {
         return NVMCTRL->INTFLAG.reg & NVMCTRL_INTFLAG_READY;

--- a/cores/arduino/Reset.cpp
+++ b/cores/arduino/Reset.cpp
@@ -43,6 +43,13 @@ static void banzai() {
 	// Disable all interrupts
 	__disable_irq();
 
+	// Avoid erasing the application if APP_START is < than the minimum bootloader size
+	// This could happen if without_bootloader linker script was chosen
+	// Minimum bootloader size in SAMD21 family is 512bytes (RM section 22.6.5)
+	if (APP_START < (0x200 + 4)) {
+		goto reset;
+	}
+
 	// Erase application
 	while (!nvmReady())
 		;
@@ -52,6 +59,7 @@ static void banzai() {
 	while (!nvmReady())
 		;
 
+reset:
 	// Reset the device
 	NVIC_SystemReset() ;
 

--- a/variants/arduino_zero/linker_scripts/gcc/flash_with_bootloader.ld
+++ b/variants/arduino_zero/linker_scripts/gcc/flash_with_bootloader.ld
@@ -65,6 +65,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/arduino_zero/linker_scripts/gcc/flash_without_bootloader.ld
+++ b/variants/arduino_zero/linker_scripts/gcc/flash_without_bootloader.ld
@@ -66,6 +66,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/arduino_zero/variant.h
+++ b/variants/arduino_zero/variant.h
@@ -19,8 +19,8 @@
 #ifndef _VARIANT_ARDUINO_ZERO_
 #define _VARIANT_ARDUINO_ZERO_
 
-// The definitions here needs a SAMD core >=1.6.6
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10606
+// The definitions here needs a SAMD core >=1.6.10
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10610
 
 /*----------------------------------------------------------------------------
  *        Definitions

--- a/variants/mkr1000/linker_scripts/gcc/flash_with_bootloader.ld
+++ b/variants/mkr1000/linker_scripts/gcc/flash_with_bootloader.ld
@@ -65,6 +65,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/mkr1000/linker_scripts/gcc/flash_without_bootloader.ld
+++ b/variants/mkr1000/linker_scripts/gcc/flash_without_bootloader.ld
@@ -66,6 +66,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/mkr1000/variant.h
+++ b/variants/mkr1000/variant.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-// The definitions here needs a SAMD core >=1.6.6
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10606
+// The definitions here needs a SAMD core >=1.6.10
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10610
 
 #include <WVariant.h>
 

--- a/variants/mkrzero/linker_scripts/gcc/flash_with_bootloader.ld
+++ b/variants/mkrzero/linker_scripts/gcc/flash_with_bootloader.ld
@@ -65,6 +65,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/mkrzero/linker_scripts/gcc/flash_without_bootloader.ld
+++ b/variants/mkrzero/linker_scripts/gcc/flash_without_bootloader.ld
@@ -66,6 +66,8 @@ SECTIONS
 {
 	.text :
 	{
+		__text_start__ = .;
+
 		KEEP(*(.isr_vector))
 		*(.text*)
 

--- a/variants/mkrzero/variant.h
+++ b/variants/mkrzero/variant.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-// The definitions here needs a SAMD core >=1.6.3
-#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10603
+// The definitions here needs a SAMD core >=1.6.10
+#define ARDUINO_SAMD_VARIANT_COMPLIANCE 10610
 
 #include <WVariant.h>
 


### PR DESCRIPTION
Superseded #184

If `ARDUINO_SAMD_VARIANT_COMPLIANCE` is >= 1.6.10 you should define ` __text_start__ ` symbol in the linker script (as in the examples). This allows `APP_START` variable to automatically acquire the right position.

Another possible improvement is checking if APP_START == 0, which means that `without_bootloader` linker script was used. In this case, calling `banzai` should be avoided and a simple restart should be performed.

@awatterott @sandeepmistry @cmaglie 
