### PR TITLE
Fix utoa type conflict

### DIFF
--- a/cores/arduino/itoa.c
+++ b/cores/arduino/itoa.c
@@ -122,7 +122,7 @@ extern char* ltoa( long value, char *string, int radix )
   return string;
 }
 
-extern char* utoa( unsigned long value, char *string, int radix )
+extern char* utoa( unsigned int value, char *string, int radix )
 {
   return ultoa( value, string, radix ) ;
 }

--- a/cores/arduino/itoa.h
+++ b/cores/arduino/itoa.h
@@ -26,7 +26,7 @@ extern "C"{
 
 extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
-extern char* utoa( unsigned long value, char *string, int radix ) ;
+extern char* utoa( unsigned int value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This is corresponding to [an issue in the main Arduino repo](https://github.com/arduino/Arduino/pull/5480).
The type conflict problem happened to me when using the new newlib/arm-gcc with Atmel Studio 7.
The fix also works with Arduino version 1.6.11.