### PR TITLE
Restore Tian functionality and update Openocd

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -293,3 +293,49 @@ mzero_bl.build.emu.mcu=atmega2560
 mzero_bl.bootloader.tool=avrdude
 mzero_bl.bootloader.low_fuses=0xff
 
+######################################################
+#ARDUINO TIAN (WITH) BOOTLOADER
+
+tian.name=Arduino Tian
+tian.upload.via_ssh=true
+tian.vid.0=0x10C4
+tian.pid.0=0xEA70
+tian.descriptor.0=Enhanced Com Port
+
+tian.upload.tool=avrdude
+#tian.upload.protocol=stk500v2
+tian.upload.protocol=wiring
+tian.upload.maximum_size=262144
+tian.upload.use_1200bps_touch=true
+tian.upload.wait_for_upload_port=true
+tian.upload.native_usb=true
+tian.upload.speed=57600
+tian.build.mcu=cortex-m0plus
+tian.build.f_cpu=48000000L
+tian.build.usb_product="Arduino Tian"
+tian.build.board=SAMD_TIAN
+tian.build.core=arduino
+tian.build.extra_flags=-D__SAMD21G18A__ -mthumb {build.usb_flags}
+tian.build.ldscript=linker_scripts/gcc/flash_with_bootloader.ld
+tian.build.openocdscript=openocd_scripts/arduino_zero.cfg
+tian.build.variant=arduino_mzero
+tian.build.variant_system_lib=
+tian.build.vid=0x2a03
+tian.build.pid=0x8052
+tian.build.preferred_out_format=hex
+tian.bootloader.size=0x4000
+tian.build.emu.mcu=atmega2560
+tian.bootloader.tool=openocd-withbootsize
+tian.bootloader.low_fuses=0xff
+tian.bootloader.file=sofia/Sofia_Tian_151118.hex
+tian.drivers=SiliconLabs-CP2105/Silicon Labs VCP Driver.pkg
+
+######################################################
+#ARDUINO TIAN CONSOLE PORT (NOT FOR UPLOAD)
+
+tian_cons.name=Arduino Tian (MIPS Console port)
+tian_cons.vid.0=0x10C4
+tian_cons.pid.0=0xEA70
+tian_cons.descriptor.0=Standard Com Port
+tian_cons.hide=true
+tian_cons.build.board=SAMD_TIAN

--- a/extras/package_index.json.PR.template
+++ b/extras/package_index.json.PR.template
@@ -35,7 +35,7 @@
               "version": "1.6.1-arduino"
             },
             {
-              "packager": "arduino",
+              "packager": "arduino-beta",
               "name": "openocd",
               "version": "0.9.0-arduino5-static"
             },

--- a/extras/package_index.json.PR.template
+++ b/extras/package_index.json.PR.template
@@ -37,7 +37,7 @@
             {
               "packager": "arduino",
               "name": "openocd",
-              "version": "0.9.0-arduino"
+              "version": "0.9.0-arduino5-static"
             },
             {
               "packager": "arduino",
@@ -53,6 +53,47 @@
         }
       ],
       "tools": [
+        {
+          "name": "openocd",
+          "version": "0.9.0-arduino5-static",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.9.0-arduino5-static-arm-linux-gnueabihf.tar.bz2",
+              "archiveFileName": "openocd-0.9.0-arduino5-static-arm-linux-gnueabihf.tar.bz2",
+              "checksum": "SHA-256:cef48c1448664612dd25168f0a56962aec4ce2f1d7c06dafd86a1b606dc8ae20",
+              "size": "1319000"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.9.0-arduino5-static-i686-w64-mingw32.zip",
+              "archiveFileName": "openocd-0.9.0-arduino5-static-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:54c70a0bfa1b0a3a592d6ee9ab532f9715e1dede2e7d46a3232abd72de274c5a",
+              "size": "1641209"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.9.0-arduino5-static-x86_64-apple-darwin15.6.0.tar.bz2",
+              "archiveFileName": "openocd-0.9.0-arduino5-static-x86_64-apple-darwin15.6.0.tar.bz22",
+              "checksum": "SHA-256:14be5c5400e1a32c3d6a15f9c8d2f438634974ab263ff437b91b527e5b5d53a4",
+              "size": "1235752"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.9.0-arduino5-static-x86_64-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.9.0-arduino5-static-x86_64-linux-gnu.tar.bz2",
+              "checksum": "SHA-256:8e378bdcd71c93a39818c16b49b91128c8028e3d9675551ba7eff39462391ba2",
+              "size": "1393855"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/openocd-0.9.0-arduino5-static-i686-linux-gnu.tar.bz2",
+              "archiveFileName": "openocd-0.9.0-arduino5-static-i686-linux-gnu.tar.bz2",
+              "checksum": "SHA-256:8e0787f54e204fe6e9071b2b7edf8a5e695492696f1182d447647fe5c0bd55bd",
+              "size": "1341739"
+            }
+          ]
+        }
       ]
     }
   ]

--- a/platform.txt
+++ b/platform.txt
@@ -145,7 +145,7 @@ tools.bossac_remote.upload.pattern=/usr/bin/run-bossac {upload.verbose} --port=t
 # OpenOCD sketch upload
 #
 
-tools.openocd.path={runtime.tools.openocd-0.9.0-arduino.path}
+tools.openocd.path={runtime.tools.openocd-0.9.0-arduino5-static.path}
 tools.openocd.cmd=bin/openocd
 tools.openocd.cmd.windows=bin/openocd.exe
 
@@ -171,7 +171,7 @@ tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/
 # FIXME: this programmer is a workaround for default options being overwritten by uploadUsingPreferences
 #
 
-tools.openocd-withbootsize.path={runtime.tools.openocd-0.9.0-arduino.path}
+tools.openocd-withbootsize.path={runtime.tools.openocd-0.9.0-arduino5-static.path}
 tools.openocd-withbootsize.cmd=bin/openocd
 tools.openocd-withbootsize.cmd.windows=bin/openocd.exe
 

--- a/platform.txt
+++ b/platform.txt
@@ -126,7 +126,7 @@ tools.avrdude.upload.params.quiet=-q -q
 tools.avrdude.upload.params.noverify=-V
 tools.avrdude.upload.pattern="{cmd}" "-C{config.path}" {upload.verbose} -p{build.emu.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
-tools.avrdude_remote.upload.pattern=/usr/bin/run-avrdude /tmp/sketch.hex
+tools.avrdude_remote.upload.pattern="openocd --version 2>&1 | grep 2017 && /usr/bin/run-avrdude /tmp/sketch.hex || echo Can't upload; update your Tian first 1>&2; exit 1"
 
 #
 # BOSSA

--- a/platform.txt
+++ b/platform.txt
@@ -20,7 +20,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5---3rd-party-Hardware-specification
 
 name=Arduino SAMD (32-bits ARM Cortex-M0+) Boards
-version=1.6.11
+version=1.6.12
 
 # Compile variables
 # -----------------
@@ -126,8 +126,7 @@ tools.avrdude.upload.params.quiet=-q -q
 tools.avrdude.upload.params.noverify=-V
 tools.avrdude.upload.pattern="{cmd}" "-C{config.path}" {upload.verbose} -p{build.emu.mcu} -c{upload.protocol} -P{serial.port} -b{upload.speed} "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
-#temporary disabled remote upload
-tools.avrdude_remote.upload.pattern=/usr/bin/XXX-run-avrdude /tmp/sketch.hex
+tools.avrdude_remote.upload.pattern=/usr/bin/run-avrdude /tmp/sketch.hex
 
 #
 # BOSSA


### PR DESCRIPTION
Use `atsamd restore` to unbrick a board

eg. 
```
openocd -d2 -s .../share/openocd/scripts/ -f .../variants/arduino_mzero/openocd_scripts/arduino_zero.cfg -c "telnet_port disabled; init; halt; at91samd restore; reset; shutdown"
```