### PR TITLE
Fix bootloader make script

### DIFF
--- a/bootloaders/zero/Makefile
+++ b/bootloaders/zero/Makefile
@@ -74,7 +74,7 @@ BIN=$(NAME).bin
 HEX=$(NAME).hex
 
 
-INCLUDES=-I"$(MODULE_PATH)/tools/CMSIS/4.5.0/CMSIS/Include/" -I"$(MODULE_PATH)/tools/CMSIS-Atmel/1.0.0/CMSIS/Device/ATMEL/"
+INCLUDES=-I"$(MODULE_PATH)/tools/CMSIS/4.5.0/CMSIS/Include/" -I"$(MODULE_PATH)/tools/CMSIS-Atmel/1.1.0/CMSIS/Device/ATMEL/"
 
 # -----------------------------------------------------------------------------
 # Linker options


### PR DESCRIPTION
https://github.com/arduino/ArduinoCore-samd/commit/5b7c293b2f9c86d1ef75708ba0ebc2755e5bd39b changed the dependency from CMSIS-Atmel 1.0.0 to 1.1.0