### PR TITLE
Correct OpenOCD version in tools.openocd.path definition

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -148,7 +148,7 @@ tools.bossac.upload.network_pattern="{network_cmd}" -address {serial.port} -port
 # OpenOCD sketch upload
 #
 
-tools.openocd.path={runtime.tools.openocd-0.9.0-arduino5-static.path}
+tools.openocd.path={runtime.tools.openocd-0.9.0-arduino6-static.path}
 tools.openocd.cmd=bin/openocd
 tools.openocd.cmd.windows=bin/openocd.exe
 
@@ -177,7 +177,7 @@ tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/
 # FIXME: this programmer is a workaround for default options being overwritten by uploadUsingPreferences
 #
 
-tools.openocd-withbootsize.path={runtime.tools.openocd-0.9.0-arduino5-static.path}
+tools.openocd-withbootsize.path={runtime.tools.openocd-0.9.0-arduino6-static.path}
 tools.openocd-withbootsize.cmd=bin/openocd
 tools.openocd-withbootsize.cmd.windows=bin/openocd.exe
 


### PR DESCRIPTION
http://downloads.arduino.cc/packages/package_index.json specifies
openocd version `0.9.0-arduino6-static` in the Arduino SAMD Boards 1.6.13
entry. The incorrect version previously used to define
`tools.openocd.path` caused uploads for SAMD boards to fail:
```
java.io.IOException: Cannot run program "{runtime.tools.openocd-0.9.0-arduino5-static.path}/bin/openocd.exe": CreateProcess error=2, The system cannot find the file specified
```