### PR TITLE
USB: Only swap incoming buffers for non-ZLP's

### DIFF
--- a/cores/arduino/USB/SAMD21_USBDevice.h
+++ b/cores/arduino/USB/SAMD21_USBDevice.h
@@ -319,30 +319,34 @@ public:
 			usbd.epBank0AckTransferComplete(ep);
 			//usbd.epBank0AckTransferFailed(ep); // XXX
 
-			// Update counters and swap banks
+			// Update counters and swap banks for non-ZLP's
 			if (incoming == 0) {
 				last0 = usbd.epBank0ByteCount(ep);
-				incoming = 1;
-				usbd.epBank0SetAddress(ep, const_cast<uint8_t *>(data1));
-				ready0 = true;
-				synchronized {
-					if (ready1) {
-						notify = true;
-						return;
+				if (last0 != 0) {
+					incoming = 1;
+					usbd.epBank0SetAddress(ep, const_cast<uint8_t *>(data1));
+					synchronized {
+						ready0 = true;
+						if (ready1) {
+							notify = true;
+							return;
+						}
+						notify = false;
 					}
-					notify = false;
 				}
 			} else {
 				last1 = usbd.epBank0ByteCount(ep);
-				incoming = 0;
-				usbd.epBank0SetAddress(ep, const_cast<uint8_t *>(data0));
-				synchronized {
-					ready1 = true;
-					if (ready0) {
-						notify = true;
-						return;
+				if (last1 != 0) {
+					incoming = 0;
+					usbd.epBank0SetAddress(ep, const_cast<uint8_t *>(data0));
+					synchronized {
+						ready1 = true;
+						if (ready0) {
+							notify = true;
+							return;
+						}
+						notify = false;
 					}
-					notify = false;
 				}
 			}
 			release();


### PR DESCRIPTION
I noticed `Serial.available()` was stuck returning `0` when I sent 1033 bytes from the Serial Monitor in the IDE from macOS. Sketch snipping:

```arduino
  do {
    if (SerialUSB.available()) {
      char c = SerialUSB.read();

       SerialUSB.print(c);

       publicCert += (char)c;
    }
  } while (!publicCert.endsWith("-----END CERTIFICATE-----"));
```

It turns out a ZLP was being received, and the USB code was swapping incoming buffers, when it didn't need to and this confused the code in `available()` which never swaps back to the other buffer.

This change prevents the swap in the USB endpoint ISR handler when a ZLP is received. NOTE: the call to `release();` is needed, this is why I didn't use the `if (last0 == 0) { return; }` style.