### PR TITLE
Implement backing storage modification in begin()

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -69,6 +69,10 @@ class HardwareSerial : public Stream
   public:
     virtual void begin(unsigned long);
     virtual void begin(unsigned long baudrate, uint16_t config);
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+    virtual void begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    virtual void begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+#endif
     virtual void end();
     virtual int available(void) = 0;
     virtual int peek(void) = 0;

--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -29,6 +29,23 @@
 
 #define RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
 
+class RxBuffer {
+public:
+  RxBuffer(uint8_t* _buf, int _size) : buf(_buf), size(_size) {}
+  uint8_t* buf;
+  int size;
+};
+
+class TxBuffer {
+public:
+  TxBuffer(uint8_t* _buf, int _size) : buf(_buf), size(_size) {}
+  uint8_t* buf;
+  int size;
+};
+
+#define TXBUFFER(x) TxBuffer(x, sizeof(x))
+#define RXBUFFER(x) RxBuffer(x, sizeof(x))
+
 class RingBuffer
 {
   public:

--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -27,6 +27,8 @@
 // location from which to read.
 #define SERIAL_BUFFER_SIZE 64
 
+#define RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+
 class RingBuffer
 {
   public:
@@ -35,16 +37,23 @@ class RingBuffer
     int _iTail ;
 
   public:
-    RingBuffer( void ) ;
-    void store_char( uint8_t c ) ;
+	RingBuffer( void ) ;
+	void store_char( uint8_t c ) ;
 	void clear();
 	int read_char();
 	int available();
 	int peek();
 	bool isFull();
+	void addStorage(uint8_t* _buffer, int _size) {
+		additionalSize = _size;
+		additionalBuffer = _buffer;
+	};
 
   private:
 	int nextIndex(int index);
+	uint8_t* additionalBuffer;
+	int additionalSize = 0;
+	int size;
 } ;
 
 #endif /* _RING_BUFFER_ */

--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -148,6 +148,21 @@ void Serial_::begin(uint32_t /* baud_count */, uint8_t /* config */)
 	// uart config is ignored in USB-CDC
 }
 
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+void Serial_::begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+{
+  begin(baudrate, config);
+  _cdc_rx_buffer->addStorage(extraRxBuffer, sizeof(extraRxBuffer));
+  // No tx buffer implemented
+  //_cdc_tx_buffer->addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+}
+
+void Serial_::begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer) {
+  begin(baudrate, SERIAL_8N1, extraTxBuffer, extraRxBuffer);
+}
+#endif
+
+
 void Serial_::end(void)
 {
 }

--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -149,16 +149,25 @@ void Serial_::begin(uint32_t /* baud_count */, uint8_t /* config */)
 }
 
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
-void Serial_::begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+void Serial_::begin(unsigned long baudrate, uint16_t config, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer)
 {
   begin(baudrate, config);
-  _cdc_rx_buffer->addStorage(extraRxBuffer, sizeof(extraRxBuffer));
-  // No tx buffer implemented
-  //_cdc_tx_buffer->addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+  uint32_t size = extraRxBuffer.size/2;
+  //usb.resize(CDC_ENDPOINT_OUT, extraRxBuffer.buf, previous_power_of_two(extraRxBuffer.size/2));
+  usb.resize(CDC_ENDPOINT_OUT, extraRxBuffer.buf, size);
 }
 
-void Serial_::begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer) {
+void Serial_::begin(unsigned long baudrate, uint16_t config, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer)
+{
+  begin(baudrate, config, extraTxBuffer, extraRxBuffer);
+}
+
+void Serial_::begin(unsigned long baudrate, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer) {
   begin(baudrate, SERIAL_8N1, extraTxBuffer, extraRxBuffer);
+}
+
+void Serial_::begin(unsigned long baudrate, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer) {
+  begin(baudrate,  extraTxBuffer, extraRxBuffer);
 }
 #endif
 

--- a/cores/arduino/USB/USBAPI.h
+++ b/cores/arduino/USB/USBAPI.h
@@ -118,7 +118,10 @@ public:
 	void begin(uint32_t baud_count);
 	void begin(unsigned long, uint8_t);
 	void end(void);
-
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+    void begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+#endif
 	virtual int available(void);
 	virtual int availableForWrite(void);
 	virtual int peek(void);

--- a/cores/arduino/USB/USBAPI.h
+++ b/cores/arduino/USB/USBAPI.h
@@ -86,6 +86,7 @@ public:
 	void initEndpoints(void);
 	void initEP(uint32_t ep, uint32_t type);
 	void handleEndpoint(uint8_t ep);
+	void resize(uint32_t ep, uint8_t *buf, uint32_t size);
 
 	uint32_t send(uint32_t ep, const void *data, uint32_t len);
 	void sendZlp(uint32_t ep);
@@ -104,12 +105,15 @@ public:
 
 private:
 	bool initialized;
+	uint32_t CDC_SERIAL_BUFFER_IN_SIZE = 256;
+	uint8_t* CDC_SERIAL_BUFFER_IN = NULL;
 };
 
 extern USBDeviceClass USBDevice;
 
 //================================================================================
 //	Serial over CDC (Serial1 is the physical port)
+
 
 class Serial_ : public Stream
 {
@@ -119,8 +123,10 @@ public:
 	void begin(unsigned long, uint8_t);
 	void end(void);
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
-    void begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
-    void begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(unsigned long baudrate, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(unsigned long baudrate, uint16_t config, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(unsigned long baudrate, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
+    void begin(unsigned long baudrate, uint16_t config, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
 #endif
 	virtual int available(void);
 	virtual int availableForWrite(void);
@@ -177,7 +183,6 @@ private:
 	int availableForStore(void);
 
 	USBDeviceClass &usb;
-	RingBuffer *_cdc_rx_buffer;
 	bool stalled;
 };
 extern Serial_ SerialUSB;

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -422,6 +422,17 @@ void USBDeviceClass::initEndpoints() {
 	}
 }
 
+void USBDeviceClass::resize(uint32_t ep, uint8_t* buf, uint32_t size)
+{
+	CDC_SERIAL_BUFFER_IN_SIZE = size;
+	CDC_SERIAL_BUFFER_IN = buf;
+
+	if (epHandlers[ep] && size != 0) {
+		delete epHandlers[ep];
+		epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, CDC_SERIAL_BUFFER_IN_SIZE, CDC_SERIAL_BUFFER_IN);
+	}
+}
+
 void USBDeviceClass::initEP(uint32_t ep, uint32_t config)
 {
 	if (config == (USB_ENDPOINT_TYPE_INTERRUPT | USB_ENDPOINT_IN(0)))
@@ -432,7 +443,9 @@ void USBDeviceClass::initEP(uint32_t ep, uint32_t config)
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0)))
 	{
-		epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, 256);
+		if (epHandlers[ep] == NULL) {
+			epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, CDC_SERIAL_BUFFER_IN_SIZE, CDC_SERIAL_BUFFER_IN);
+		}
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0)))
 	{

--- a/cores/arduino/Uart.cpp
+++ b/cores/arduino/Uart.cpp
@@ -46,6 +46,20 @@ void Uart::begin(unsigned long baudrate, uint16_t config)
   sercom->enableUART();
 }
 
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+void Uart::begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+{
+  begin(baudrate, config);
+  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
+  // No tx buffer implemented
+  //txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+}
+
+void Uart::begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer) {
+  begin(baudrate, SERIAL_8N1, extraTxBuffer, extraRxBuffer);
+}
+#endif
+
 void Uart::end()
 {
   sercom->resetUART();

--- a/cores/arduino/Uart.cpp
+++ b/cores/arduino/Uart.cpp
@@ -47,16 +47,25 @@ void Uart::begin(unsigned long baudrate, uint16_t config)
 }
 
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
-void Uart::begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+void Uart::begin(unsigned long baudrate, uint16_t config, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer)
 {
   begin(baudrate, config);
-  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
+  rxBuffer.addStorage(extraRxBuffer.buf, extraRxBuffer.size);
   // No tx buffer implemented
   //txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
 }
 
-void Uart::begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer) {
+void Uart::begin(unsigned long baudrate, uint16_t config, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer)
+{
+  begin(baudrate, config, extraTxBuffer, extraRxBuffer);
+}
+
+void Uart::begin(unsigned long baudrate, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer) {
   begin(baudrate, SERIAL_8N1, extraTxBuffer, extraRxBuffer);
+}
+
+void Uart::begin(unsigned long baudrate, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer) {
+  begin(baudrate,  extraTxBuffer, extraRxBuffer);
 }
 #endif
 

--- a/cores/arduino/Uart.h
+++ b/cores/arduino/Uart.h
@@ -30,6 +30,10 @@ class Uart : public HardwareSerial
     Uart(SERCOM *_s, uint8_t _pinRX, uint8_t _pinTX, SercomRXPad _padRX, SercomUartTXPad _padTX);
     void begin(unsigned long baudRate);
     void begin(unsigned long baudrate, uint16_t config);
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+    void begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+#endif
     void end();
     int available();
     int availableForWrite();

--- a/cores/arduino/Uart.h
+++ b/cores/arduino/Uart.h
@@ -31,8 +31,10 @@ class Uart : public HardwareSerial
     void begin(unsigned long baudRate);
     void begin(unsigned long baudrate, uint16_t config);
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
-    void begin(unsigned long baudrate, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
-    void begin(unsigned long baudrate, uint16_t config, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(unsigned long baudrate, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(unsigned long baudrate, uint16_t config, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(unsigned long baudrate, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
+    void begin(unsigned long baudrate, uint16_t config, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
 #endif
     void end();
     int available();

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -52,6 +52,24 @@ void TwoWire::begin(uint8_t address) {
   pinPeripheral(_uc_pinSCL, g_APinDescription[_uc_pinSCL].ulPinType);
 }
 
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+
+void TwoWire::begin(uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+{
+  begin();
+  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
+  txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+}
+
+void TwoWire::begin(uint8_t address, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+{
+  begin(address);
+  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
+  txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+}
+
+#endif
+
 void TwoWire::setClock(uint32_t baudrate) {
   sercom->disableWIRE();
   sercom->initMasterWIRE(baudrate);

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -54,18 +54,36 @@ void TwoWire::begin(uint8_t address) {
 
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
 
-void TwoWire::begin(uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+void TwoWire::begin(TxBuffer extraTxBuffer, RxBuffer extraRxBuffer)
 {
   begin();
-  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
-  txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+  if (extraRxBuffer.buf != NULL) {
+    rxBuffer.addStorage(extraRxBuffer.buf, extraRxBuffer.size);
+  }
+  if (extraTxBuffer.buf != NULL) {
+    txBuffer.addStorage(extraTxBuffer.buf, extraTxBuffer.size);
+  }
 }
 
-void TwoWire::begin(uint8_t address, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer)
+void TwoWire::begin(RxBuffer extraRxBuffer, TxBuffer extraTxBuffer)
+{
+  begin(extraTxBuffer, extraRxBuffer);
+}
+
+void TwoWire::begin(uint8_t address, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer)
 {
   begin(address);
-  rxBuffer.addStorage(extraRxBuffer, sizeof(extraRxBuffer));
-  txBuffer.addStorage(extraTxBuffer, sizeof(extraTxBuffer));
+  if (extraRxBuffer.buf != NULL) {
+    rxBuffer.addStorage(extraRxBuffer.buf, extraRxBuffer.size);
+  }
+  if (extraTxBuffer.buf != NULL) {
+    txBuffer.addStorage(extraTxBuffer.buf, extraTxBuffer.size);
+  }
+}
+
+void TwoWire::begin(uint8_t address, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer)
+{
+  begin(address, extraTxBuffer, extraRxBuffer);
 }
 
 #endif

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -36,8 +36,10 @@ class TwoWire : public Stream
     void begin();
     void begin(uint8_t);
 #ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
-    void begin(uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
-    void begin(uint8_t address, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(uint8_t address, TxBuffer extraTxBuffer, RxBuffer extraRxBuffer = RxBuffer(NULL,0));
+    void begin(RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
+    void begin(uint8_t address, RxBuffer extraRxBuffer, TxBuffer extraTxBuffer = TxBuffer(NULL,0));
 #endif
     void end();
     void setClock(uint32_t);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -35,6 +35,10 @@ class TwoWire : public Stream
     TwoWire(SERCOM *s, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);
+#ifdef RINGBUFFER_HAS_ADDITIONAL_STORAGE_API
+    void begin(uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+    void begin(uint8_t address, uint8_t* extraTxBuffer, uint8_t* extraRxBuffer);
+#endif
     void end();
     void setClock(uint32_t);
 


### PR DESCRIPTION
Following the conversation on dev mailing list, this is a proof of concept about overloading `begin()` for a couple of classes (namely, the ones using internal buffers as storage) .

There are a couple of helper functions to allow conveniently wrapping buffers (and to avoid confusion about the order).

The example usage will look like 

```arduino
#include "Wire.h"

byte auxBuffer[1024];
byte wireRxBuffer[128];
byte wireTxBuffer[16];

void setup() {
  // all valid
   SerialUSB.begin(9600, RXBUFFER(auxBuffer));
   Serial.begin(9600, TXBUFFER(auxBuffer));
   Wire.begin(TXBUFFER(wireTxBuffer), RXBUFFER(wireRxBuffer));
```
There is still a small incoherence (CDC buffer is replaced, not expanded) but the main concept is here.
Feel free to comment and propose changes, thanks! @sandeepmistry @tigoe @PaulStoffregen