### PR TITLE
Use SAMD21 serial number for USB serial number prefix

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -221,8 +221,15 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 		}
 		else if (setup.wValueL == ISERIAL) {
 #ifdef PLUGGABLE_USB_ENABLED
+			// from section 9.3.3 of the datasheet
+			#define SERIAL_NUMBER_WORD_0	*(volatile uint32_t*)(0x0080A00C)
+			#define SERIAL_NUMBER_WORD_1	*(volatile uint32_t*)(0x0080A040)
+			#define SERIAL_NUMBER_WORD_2	*(volatile uint32_t*)(0x0080A044)
+			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
+
 			char name[ISERIAL_MAX_LEN];
-			PluggableUSB().getShortName(name);
+			sprintf(name, "%8X%8X%8X%8X", SERIAL_NUMBER_WORD_0, SERIAL_NUMBER_WORD_1, SERIAL_NUMBER_WORD_2, SERIAL_NUMBER_WORD_3);
+			PluggableUSB().getShortName(&name[32]);
 			return sendStringDescriptor((uint8_t*)name, setup.wLength);
 #endif
 		}

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -177,21 +177,12 @@ uint32_t USBDeviceClass::sendConfiguration(uint32_t maxlen)
 	return true;
 }
 
-static void utox(uint32_t val, char* s) {
-	// lead zero pad
-	for (uint32_t i = 0x10000000; i > 1; i = i >> 4) {
-		if (val < i) {
-			*s++ = '0';
-		}
-	}
+static void utox8(uint32_t val, char* s) {
+	for (int i = 0; i < 8; i++) {
+		int d = val & 0XF;
+		val = (val >> 4);
 
-	// convert value to hex string
-	utoa(val, s, 16);
-
-	// make string uppercase
-	while (s && *s) {
-		*s = toupper(*s);
-		s++;
+		s[7 - i] = d > 9 ? 'A' + d - 10 : '0' + d;
 	}
 }
 
@@ -246,10 +237,10 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
 
 			char name[ISERIAL_MAX_LEN];
-			utox(SERIAL_NUMBER_WORD_0, &name[0]);
-			utox(SERIAL_NUMBER_WORD_1, &name[8]);
-			utox(SERIAL_NUMBER_WORD_2, &name[16]);
-			utox(SERIAL_NUMBER_WORD_3, &name[24]);
+			utox8(SERIAL_NUMBER_WORD_0, &name[0]);
+			utox8(SERIAL_NUMBER_WORD_1, &name[8]);
+			utox8(SERIAL_NUMBER_WORD_2, &name[16]);
+			utox8(SERIAL_NUMBER_WORD_3, &name[24]);
 
 			PluggableUSB().getShortName(&name[32]);
 			return sendStringDescriptor((uint8_t*)name, setup.wLength);

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -177,6 +177,24 @@ uint32_t USBDeviceClass::sendConfiguration(uint32_t maxlen)
 	return true;
 }
 
+static void utox(uint32_t val, char* s) {
+	// lead zero pad
+	for (uint32_t i = 0x10000000; i > 1; i = i >> 4) {
+		if (val < i) {
+			*s++ = '0';
+		}
+	}
+
+	// convert value to hex string
+	utoa(val, s, 16);
+
+	// make string uppercase
+	while (s && *s) {
+		*s = toupper(*s);
+		s++;
+	}
+}
+
 bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 {
 	uint8_t t = setup.wValueH;
@@ -228,7 +246,11 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 			#define SERIAL_NUMBER_WORD_3	*(volatile uint32_t*)(0x0080A048)
 
 			char name[ISERIAL_MAX_LEN];
-			sprintf(name, "%8X%8X%8X%8X", SERIAL_NUMBER_WORD_0, SERIAL_NUMBER_WORD_1, SERIAL_NUMBER_WORD_2, SERIAL_NUMBER_WORD_3);
+			utox(SERIAL_NUMBER_WORD_0, &name[0]);
+			utox(SERIAL_NUMBER_WORD_1, &name[8]);
+			utox(SERIAL_NUMBER_WORD_2, &name[16]);
+			utox(SERIAL_NUMBER_WORD_3, &name[24]);
+
 			PluggableUSB().getShortName(&name[32]);
 			return sendStringDescriptor((uint8_t*)name, setup.wLength);
 #endif

--- a/cores/arduino/USB/USBDesc.h
+++ b/cores/arduino/USB/USBDesc.h
@@ -41,7 +41,7 @@
 #define CDC_TX CDC_ENDPOINT_IN
 #endif
 
-#define ISERIAL_MAX_LEN        33
+#define ISERIAL_MAX_LEN        65
 
 // Defined string description
 #define IMANUFACTURER	1


### PR DESCRIPTION
This is based on section 9.3.3 of the data sheet.

With this change, Blink is 1948 bytes larger on a MKR1000 (without change 9256 bytes, with change 11204 bytes).

Anyone know of a slimmer way to convert a register value to a hex string?