### PR TITLE
Fix for pgm_read_ptr macro

### DIFF
--- a/cores/arduino/avr/pgmspace.h
+++ b/cores/arduino/avr/pgmspace.h
@@ -103,7 +103,7 @@ typedef const void* uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(const void **)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
This is a fix for the same problem as for SAM platform. See https://github.com/arduino/ArduinoCore-sam/pull/43