### PR TITLE
Improve interrupt handling response time

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -21,15 +21,15 @@
 
 #include <string.h>
 
-static voidFuncPtr ISRcallback[EXTERNAL_NUM_INTERRUPTS];
+static voidFuncPtr     ISRcallback[EXTERNAL_NUM_INTERRUPTS];
 static EExt_Interrupts ISRlist[EXTERNAL_NUM_INTERRUPTS];
-static uint32_t nints; // Stores total number of attached interrupts
+static uint32_t        nints; // Stores total number of attached interrupts
 
 
 /* Configure I/O interrupt sources */
 static void __initialize()
 {
-  memset(ISRlist, 0, sizeof(ISRlist));
+  memset(ISRlist,     0, sizeof(ISRlist));
   memset(ISRcallback, 0, sizeof(ISRcallback));
   nints = 0;
 
@@ -88,7 +88,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
   {
     // Store interrupts to service in order of when they were attached
     // to allow for first come first serve handler
-    uint32_t current=0;
+    uint32_t current = 0;
 
     // Check if we already have this interrupt
     for (current=0; current<nints; current++) {
@@ -100,7 +100,7 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
       // Need to make a new entry
       nints++;
     }
-    ISRlist[current] = in; // List with nr of interrupt in order of when they were attached
+    ISRlist[current] = in;           // List of interrupt in order of when they were attached
     ISRcallback[current] = callback; // List of callback adresses
 
     // Look for right CONFIG register to be addressed

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -174,9 +174,6 @@ void detachInterrupt(uint32_t pin)
       ISRlist[i] = ISRlist[i+1];
       ISRcallback[i] = ISRcallback[i+1];
   }
-  // And remove the top item
-  ISRlist[nints]=0;
-  ISRcallback[nints]=NULL;
   nints--;
 }
 

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -91,18 +91,14 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
     uint32_t current=0;
 
     // Check if we already have this interrupt
-    int id = -1;
-    for (uint32_t i=0; i<nints; i++) {
-      if (ISRlist[i] == in) id = in;
+    for (current=0; current<nints; current++) {
+      if (ISRlist[current] == in) {
+        break;
+      }
     }
-
-    if (id == -1) {
+    if (current == nints) {
       // Need to make a new entry
-      current = nints;
       nints++;
-    } else {
-      // We already have an entry for this pin
-      current = id;
     }
     ISRlist[current] = in; // List with nr of interrupt in order of when they were attached
     ISRcallback[current] = callback; // List of callback adresses
@@ -163,16 +159,18 @@ void detachInterrupt(uint32_t pin)
   EIC->WAKEUP.reg &= ~(1 << in);
 
   // Remove callback from the ISR list
-  int id = -1;
-  for (uint32_t i=0; i<nints; i++) {
-      if (ISRlist[i] == in) id = in;
+  uint32_t current;
+  for (current=0; current<nints; current++) {
+    if (ISRlist[current] == in) {
+      break;
+    }
   }
-  if (id == -1) return; // We didn't have it
+  if (current == nints) return; // We didn't have it
 
   // Shift the reminder down
-  for (uint32_t i=id; i<nints-1; i++) {
-      ISRlist[i] = ISRlist[i+1];
-      ISRcallback[i] = ISRcallback[i+1];
+  for (; current<nints-1; current++) {
+    ISRlist[current]     = ISRlist[current+1];
+    ISRcallback[current] = ISRcallback[current+1];
   }
   nints--;
 }

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -106,12 +106,13 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
     // Look for right CONFIG register to be addressed
     if (in > EXTERNAL_INT_7) {
       config = 1;
+      pos = (in - 8) << 2;
     } else {
       config = 0;
+      pos = in << 2;
     }
 
     // Configure the interrupt mode
-    pos = (in - (8 * config)) << 2;
     EIC->CONFIG[config].reg &=~ (EIC_CONFIG_SENSE0_Msk << pos); // Reset sense mode, important when changing trigger mode during runtime
     switch (mode)
     {


### PR DESCRIPTION
Built on top of @joverbee's patch #201 

- Fix some errors handling ISR list during re-attach/detach
- put interrupt mask instead of interrupt number inside ISRlist, this allows to save a bit shift inside the loop in `EIC_Handler`

@joverbee I see that you added a case to allow passing NULL as a callback:

https://github.com/arduino/ArduinoCore-samd/commit/9a49ce2fc4d4944dc84c33778339306b092816c8#diff-2d6f462f44c0386e70bfb9e3ba804d5bR87

may you explain better what's the purpose of this?