### PR TITLE
Prevent full UART TX buffer from hanging processor

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -681,7 +681,7 @@ void SERCOM::initClockNVIC( void )
 
   // Setting NVIC
   NVIC_EnableIRQ(IdNvic);
-  NVIC_SetPriority (IdNvic, (1<<__NVIC_PRIO_BITS) - 1);  /* set Priority */
+  NVIC_SetPriority (IdNvic, SERCOM_NVIC_PRIORITY);  /* set Priority */
 
   //Setting clock
   GCLK->CLKCTRL.reg = GCLK_CLKCTRL_ID( clockId ) | // Generic Clock 0 (SERCOMx)

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -21,7 +21,8 @@
 
 #include "sam.h"
 
-#define SERCOM_FREQ_REF 48000000
+#define SERCOM_FREQ_REF      48000000
+#define SERCOM_NVIC_PRIORITY ((1<<__NVIC_PRIO_BITS) - 1)
 
 typedef enum
 {


### PR DESCRIPTION
Similar to https://github.com/arduino/ArduinoCore-samd/pull/260, but with additional checks.

When `UART::write(b)` is called and the TX buffer is full it will now manually call the DRE IRQ handler if: 
* interrupts are currently disabled
or
* the current IRQ (exception number) has a higher or equal priority than the SERCOM IRQ
