### PR TITLE
Add new Wire.sendTo(...) and Wire.requestFrom(...) API's that use external buffer

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -62,12 +62,12 @@ void TwoWire::end() {
   sercom->disableWIRE();
 }
 
-uint8_t TwoWire::sentTo(uint8_t address, uint8_t buffer[], size_t quantity)
+uint8_t TwoWire::sendTo(uint8_t address, uint8_t buffer[], size_t quantity)
 {
-  return sentTo(address, buffer, quantity, true);
+  return sendTo(address, buffer, quantity, true);
 }
 
-uint8_t TwoWire::sentTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit)
+uint8_t TwoWire::sendTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit)
 {
   // Start I2C transmission
   if (!sercom->startTransmissionWIRE(address, WIRE_WRITE_FLAG))
@@ -169,7 +169,7 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 {
   transmissionBegun = false ;
 
-  uint8_t result = sentTo(txAddress, txBuffer._aucBuffer, txBuffer.available(), stopBit);
+  uint8_t result = sendTo(txAddress, txBuffer._aucBuffer, txBuffer.available(), stopBit);
 
   if (result == 0) {
     txBuffer.clear();

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -42,8 +42,8 @@ class TwoWire : public Stream
     uint8_t endTransmission(bool stopBit);
     uint8_t endTransmission(void);
 
-    uint8_t sentTo(uint8_t address, uint8_t buffer[], size_t quantity);
-    uint8_t sentTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);
+    uint8_t sendTo(uint8_t address, uint8_t buffer[], size_t quantity);
+    uint8_t sendTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);
 
     uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
     uint8_t requestFrom(uint8_t address, size_t quantity);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -42,8 +42,13 @@ class TwoWire : public Stream
     uint8_t endTransmission(bool stopBit);
     uint8_t endTransmission(void);
 
+    uint8_t sentTo(uint8_t address, uint8_t buffer[], size_t quantity);
+    uint8_t sentTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);
+
     uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
     uint8_t requestFrom(uint8_t address, size_t quantity);
+    uint8_t requestFrom(uint8_t address, uint8_t buffer[], size_t quantity);
+    uint8_t requestFrom(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);
 
     size_t write(uint8_t data);
     size_t write(const uint8_t * data, size_t quantity);


### PR DESCRIPTION
Proposal to add new Wire lib API's that allow the caller to specify an external buffer to use. Use cases:

* to avoid extra overheads of using Wire's internal buffer + Stream API's
* when the size of Wire's internal buffer is not large enough

New APIs:
```c
uint8_t sendTo(uint8_t address, uint8_t buffer[], size_t quantity);
uint8_t sendTo(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);

uint8_t requestFrom(uint8_t address, uint8_t buffer[], size_t quantity);
uint8_t requestFrom(uint8_t address, uint8_t buffer[], size_t quantity, bool stopBit);
```