### PR TITLE
Fixed the iManufacturer and iProduct HID string descriptor functions

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -223,10 +223,10 @@ bool USBDeviceClass::sendDescriptor(USBSetup &setup)
 			desc_addr = (const uint8_t*)&STRING_LANGUAGE;
 		}
 		else if (setup.wValueL == IPRODUCT) {
-			return sendStringDescriptor(STRING_PRODUCT, setup.wLength);
+			return sendStringDescriptor(STRING_PRODUCT, 2*sizeof(STRING_PRODUCT)); // Unicode is 2 bytes
 		}
 		else if (setup.wValueL == IMANUFACTURER) {
-			return sendStringDescriptor(STRING_MANUFACTURER, setup.wLength);
+			return sendStringDescriptor(STRING_MANUFACTURER, 2*sizeof(STRING_MANUFACTURER));
 		}
 		else if (setup.wValueL == ISERIAL) {
 #ifdef PLUGGABLE_USB_ENABLED


### PR DESCRIPTION
iManucaturer and iProduct were not properly written for HID devices, as the setup.wlength struct element did not represent the real length of the string descriptor.

This caused HID driver errors on Windows AMD_64.

String descriptors are supposed to be in unicode, so 2*sizeof(string) gives the proper length.