### PR TITLE
Avoid read-modify-write when enabling SERCOM DRE interrupt

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -175,7 +175,7 @@ int SERCOM::writeDataUART(uint8_t data)
 
 void SERCOM::enableDataRegisterEmptyInterruptUART()
 {
-  sercom->USART.INTENSET.reg |= SERCOM_USART_INTENSET_DRE;
+  sercom->USART.INTENSET.reg = SERCOM_USART_INTENSET_DRE;
 }
 
 void SERCOM::disableDataRegisterEmptyInterruptUART()


### PR DESCRIPTION
The disable interrupt already does it like this. Just write the value of the DRE bit, no read-modify-write operation is needed.