### PR TITLE
Allow General Calls on I2C bus (aka broadcast)

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -400,7 +400,7 @@ void SERCOM::disableWIRE()
   }
 }
 
-void SERCOM::initSlaveWIRE( uint8_t ucAddress, bool broadcast )
+void SERCOM::initSlaveWIRE( uint8_t ucAddress, bool enableGeneralCall )
 {
   // Initialize the peripheral clock and interruption
   initClockNVIC() ;
@@ -411,7 +411,7 @@ void SERCOM::initSlaveWIRE( uint8_t ucAddress, bool broadcast )
 
   sercom->I2CS.ADDR.reg = SERCOM_I2CS_ADDR_ADDR( ucAddress & 0x7Ful ) | // 0x7F, select only 7 bits
                           SERCOM_I2CS_ADDR_ADDRMASK( 0x00ul );          // 0x00, only match exact address
-  if (broadcast) {
+  if (enableGeneralCall) {
     sercom->I2CS.ADDR.reg |= SERCOM_I2CS_ADDR_GENCEN;                   // enable general call (address 0x00)
   }
 

--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -370,7 +370,7 @@ void SERCOM::enableWIRE()
 {
   // I2C Master and Slave modes share the ENABLE bit function.
 
-  // Enable the I²C master mode
+  // Enable the I2C master mode
   sercom->I2CM.CTRLA.bit.ENABLE = 1 ;
 
   while ( sercom->I2CM.SYNCBUSY.bit.ENABLE != 0 )
@@ -391,7 +391,7 @@ void SERCOM::disableWIRE()
 {
   // I2C Master and Slave modes share the ENABLE bit function.
 
-  // Enable the I²C master mode
+  // Enable the I2C master mode
   sercom->I2CM.CTRLA.bit.ENABLE = 0 ;
 
   while ( sercom->I2CM.SYNCBUSY.bit.ENABLE != 0 )
@@ -400,17 +400,20 @@ void SERCOM::disableWIRE()
   }
 }
 
-void SERCOM::initSlaveWIRE( uint8_t ucAddress )
+void SERCOM::initSlaveWIRE( uint8_t ucAddress, bool broadcast )
 {
   // Initialize the peripheral clock and interruption
   initClockNVIC() ;
   resetWIRE() ;
 
   // Set slave mode
-  sercom->I2CS.CTRLA.bit.MODE = I2C_SLAVE_OPERATION ;
+  sercom->I2CS.CTRLA.bit.MODE = I2C_SLAVE_OPERATION;
 
   sercom->I2CS.ADDR.reg = SERCOM_I2CS_ADDR_ADDR( ucAddress & 0x7Ful ) | // 0x7F, select only 7 bits
-                          SERCOM_I2CS_ADDR_ADDRMASK( 0x00ul ) ;         // 0x00, only match exact address
+                          SERCOM_I2CS_ADDR_ADDRMASK( 0x00ul );          // 0x00, only match exact address
+  if (broadcast) {
+    sercom->I2CS.ADDR.reg |= SERCOM_I2CS_ADDR_GENCEN;                   // enable general call (address 0x00)
+  }
 
   // Set the interrupt register
   sercom->I2CS.INTENSET.reg = SERCOM_I2CS_INTENSET_PREC |   // Stop

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -184,7 +184,7 @@ class SERCOM
 		bool isReceiveCompleteSPI( void ) ;
 
 		/* ========== WIRE ========== */
-		void initSlaveWIRE(uint8_t address) ;
+		void initSlaveWIRE(uint8_t address, bool broadcast = false) ;
 		void initMasterWIRE(uint32_t baudrate) ;
 
 		void resetWIRE( void ) ;

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -184,7 +184,7 @@ class SERCOM
 		bool isReceiveCompleteSPI( void ) ;
 
 		/* ========== WIRE ========== */
-		void initSlaveWIRE(uint8_t address, bool broadcast = false) ;
+		void initSlaveWIRE(uint8_t address, bool enableGeneralCall = false) ;
 		void initMasterWIRE(uint32_t baudrate) ;
 
 		void resetWIRE( void ) ;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -43,9 +43,9 @@ void TwoWire::begin(void) {
   pinPeripheral(_uc_pinSCL, g_APinDescription[_uc_pinSCL].ulPinType);
 }
 
-void TwoWire::begin(uint8_t address) {
+void TwoWire::begin(uint8_t address, bool broadcast) {
   //Slave mode
-  sercom->initSlaveWIRE(address);
+  sercom->initSlaveWIRE(address, broadcast);
   sercom->enableWIRE();
 
   pinPeripheral(_uc_pinSDA, g_APinDescription[_uc_pinSDA].ulPinType);

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -43,9 +43,9 @@ void TwoWire::begin(void) {
   pinPeripheral(_uc_pinSCL, g_APinDescription[_uc_pinSCL].ulPinType);
 }
 
-void TwoWire::begin(uint8_t address, bool broadcast) {
+void TwoWire::begin(uint8_t address, bool enableGeneralCall) {
   //Slave mode
-  sercom->initSlaveWIRE(address, broadcast);
+  sercom->initSlaveWIRE(address, enableGeneralCall);
   sercom->enableWIRE();
 
   pinPeripheral(_uc_pinSDA, g_APinDescription[_uc_pinSDA].ulPinType);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -34,7 +34,7 @@ class TwoWire : public Stream
   public:
     TwoWire(SERCOM *s, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
-    void begin(uint8_t, bool broadcast = false);
+    void begin(uint8_t, bool enableGeneralCall = false);
     void end();
     void setClock(uint32_t);
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -34,7 +34,7 @@ class TwoWire : public Stream
   public:
     TwoWire(SERCOM *s, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
-    void begin(uint8_t);
+    void begin(uint8_t, bool broadcast = false);
     void end();
     void setClock(uint32_t);
 


### PR DESCRIPTION
This allow to call a Wire.begin(address, true) to enable general call (broadcast messages on address 0x00) feature on SAMD21 based devices. All the legacy calls to Wire.begin(address) are ok since the extra parameter is false by default