### PR TITLE
Check for loss of arbitration

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -370,7 +370,7 @@ void SERCOM::enableWIRE()
 {
   // I2C Master and Slave modes share the ENABLE bit function.
 
-  // Enable the I²C master mode
+  // Enable the IÂ²C master mode
   sercom->I2CM.CTRLA.bit.ENABLE = 1 ;
 
   while ( sercom->I2CM.SYNCBUSY.bit.ENABLE != 0 )
@@ -391,7 +391,7 @@ void SERCOM::disableWIRE()
 {
   // I2C Master and Slave modes share the ENABLE bit function.
 
-  // Enable the I²C master mode
+  // Enable the IÂ²C master mode
   sercom->I2CM.CTRLA.bit.ENABLE = 0 ;
 
   while ( sercom->I2CM.SYNCBUSY.bit.ENABLE != 0 )
@@ -496,6 +496,12 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
     while( !sercom->I2CM.INTFLAG.bit.MB )
     {
       // Wait transmission complete
+    }
+    // Check for loss of arbitration (multiple masters starting communication at the same time)
+    if(!isBusOwnerWIRE())
+    {
+      // Restart communication
+      startTransmissionWIRE(address >> 1, flag);
     }
   }
   else  // Read mode


### PR DESCRIPTION
When initiating an I2C communication as master, there is a chance of losing arbitration of the bus if there are other masters on the bus. This is a perfectly normal scenario and it is handled by trying to start the communication again. If arbitration was lost during the first try, now the bus state is busy so the second call to startTransmissionWIRE will wait until the bus is idle again before retrying.
I made this change on my MKRZERO over a month ago and since then I didn't have any more errors. I have a system with 7 masters on the same I2C bus sending messages at about 10Hz each, so loss of arbitration happens frequently (2 masters starting to communicate at the same time). One of the 2 gets priority over the other while the other loses arbitration. The loser simply retries the communication when loss of arbitration is detected, and everything works smoothly without data loss.
Without this check we can't be aware of any loss of arbitration and the library would detect the NACK without understanding that it was not a real NACK from the slave.