### PR TITLE
Add missing USBCON wrapper

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -16,6 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#if defined(USBCON)
+
 #include <Arduino.h>
 
 #include "SAMD21_USBDevice.h"
@@ -968,3 +970,4 @@ void USBDeviceClass::ISRHandler()
 // USBDevice class instance
 USBDeviceClass USBDevice;
 
+#endif


### PR DESCRIPTION
If the following `boards.txt` entry is applied: `<board>.build.usb_flags=`, the build fails because of a missing `#if defined(USBCON)` check. This change adds it.