### PR TITLE
Fix calculation of SPI_MIN_CLOCK_DIVIDER in SPI.h

### DIFF
--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -37,14 +37,12 @@
 #define SPI_MODE2 0x03
 #define SPI_MODE3 0x01
 
-#if defined(__SAMD21G18A__)
-  // Even if not specified on the datasheet, the SAMD21G18A MCU
-  // doesn't operate correctly with clock dividers lower than 4.
-  // This allows a theoretical maximum SPI clock speed of 12Mhz
-  #define SPI_MIN_CLOCK_DIVIDER 4
-  // Other SAMD21xxxxx MCU may be affected as well
-#else
-  #define SPI_MIN_CLOCK_DIVIDER 2
+#if defined(ARDUINO_ARCH_SAMD)
+  // The datasheet specifies a typical SPI SCK period (tSCK) of 42 ns,
+  // see "Table 36-48. SPI Timing Characteristics and Requirements",
+  // which translates into a maximum SPI clock of 23.8 MHz.
+  // Conservatively, the divider is set for a 12 MHz maximum SPI clock.
+  #define SPI_MIN_CLOCK_DIVIDER (uint8_t)(1 + ((F_CPU - 1) / 12000000))
 #endif
 
 class SPISettings {


### PR DESCRIPTION
The previous version of SPI.h works only for the SAMD21G18A variant and only for a 48 MHz system clock. For the rest of variants, it sets SPI_MIN_CLOCK_DIVIDER to 2, which is incorrect for a 48 MHz system clock.

The SAMD21 datasheet specifies a typical SPI SCK period (tSCK) of 42 ns, see "Table 36-48. SPI Timing Characteristics and Requirements", which translates into a maximum SPI clock of 23.8 MHz.

The new code conservatively sets the divider for a 12 MHz maximum SPI clock, taking into account any value for the system clock (not only 48 MHz). It also executes for other variants of the SAMD, not only SAMD21G18A.

Can you, please, review this patch?