### PR TITLE
Don't reallocate USB buffers if already allocated

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -454,7 +454,9 @@ void USBDeviceClass::initEP(uint32_t ep, uint32_t config)
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0)))
 	{
-		epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, 256);
+		if (epHandlers[ep] == NULL) {
+			epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, 256);
+		}
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0)))
 	{


### PR DESCRIPTION
USB Configuration was meant to run only once, but if the board comes back from standby the host can reconfigure the device again.
Probably a cleaner patch could be free()-ing the buffers on standby() to release the memory but at least we don't leak anymore.

Fixes https://github.com/arduino/ArduinoCore-samd/issues/293