### PR TITLE
Make ring buffer head and tail indexes volatile

### DIFF
--- a/cores/arduino/RingBuffer.h
+++ b/cores/arduino/RingBuffer.h
@@ -34,8 +34,8 @@ class RingBufferN
 {
   public:
     uint8_t _aucBuffer[N] ;
-    int _iHead ;
-    int _iTail ;
+    volatile int _iHead ;
+    volatile int _iTail ;
 
   public:
     RingBufferN( void ) ;


### PR DESCRIPTION
I was having some issues running some MKRGSM lib examples with the latest SAMD core master. 503a9b39545aeb09e610aec0f639a7f6a7949368 introduced an issue, however making the ring buffer head and tail indexes volatile allows things to work again. They probably should have been volatile in the original non-templated version.