### PR TITLE
Fix CDC_ENABLED

### DIFF
--- a/cores/arduino/USB/USBDesc.h
+++ b/cores/arduino/USB/USBDesc.h
@@ -26,6 +26,9 @@
 #ifdef CDC_ENABLED
 #define CDC_INTERFACE_COUNT 2
 #define CDC_ENPOINT_COUNT 3
+#else
+#define CDC_INTERFACE_COUNT 0
+#define CDC_ENPOINT_COUNT 0
 #endif
 
 // CDC


### PR DESCRIPTION
Undefining CDC_ENABLED triggered a compiler error. With this fix, the CDC ACM configuration can be disabled.