### PR TITLE
[SPI] Fix interrupt mask to block

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -105,7 +105,7 @@ void SPIClass::usingInterrupt(int interruptNumber)
   else
   {
     interruptMode |= SPI_IMODE_EXTINT;
-    interruptMask |= (1 << interruptNumber);
+    interruptMask |= (1 << g_APinDescription[interruptNumber].ulExtInt);
   }
 
   if (irestore)
@@ -123,7 +123,7 @@ void SPIClass::notUsingInterrupt(int interruptNumber)
   uint8_t irestore = interruptsStatus();
   noInterrupts();
 
-  interruptMask &= ~(1 << interruptNumber);
+  interruptMask &= ~(1 << g_APinDescription[interruptNumber].ulExtInt);
 
   if (interruptMask == 0)
     interruptMode = SPI_IMODE_NONE;


### PR DESCRIPTION
Digital pin number is not equivalent to SAMD interrupt number (in EIC module).
Mapping is provided by `g_APinDescription` pin map. 

However, this solution assumes that interrupt number is equal to digital pin number (which holds true for SAMD devices):
https://github.com/arduino/ArduinoCore-samd/blob/d2b2ff928ebf9b34a1621f50949e1f5cf088b21d/cores/arduino/Arduino.h#L124

Fix for https://github.com/arduino/ArduinoCore-samd/issues/316.