### PR TITLE
I2S: Use 8 MHz oscillator source if 48MHz divider does not fit in 8 bits

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -398,15 +398,24 @@ void I2SClass::onReceive(void(*function)(void))
 
 void I2SClass::enableClock(int divider)
 {
+  int div = SystemCoreClock / divider;
+  int src = GCLK_GENCTRL_SRC_DFLL48M_Val;
+
+  if (div > 255) {
+    // divider is too big, use 8 MHz oscillator instead
+    div = 8000000 / divider;
+    src = GCLK_GENCTRL_SRC_OSC8M_Val;
+  }
+
   // configure the clock divider
   while (GCLK->STATUS.bit.SYNCBUSY);
   GCLK->GENDIV.bit.ID = _clockGenerator;
-  GCLK->GENDIV.bit.DIV = SystemCoreClock / divider;
+  GCLK->GENDIV.bit.DIV = div;
 
   // use the DFLL as the source
   while (GCLK->STATUS.bit.SYNCBUSY);
   GCLK->GENCTRL.bit.ID = _clockGenerator;
-  GCLK->GENCTRL.bit.SRC = GCLK_GENCTRL_SRC_DFLL48M_Val;
+  GCLK->GENCTRL.bit.SRC = src;
   GCLK->GENCTRL.bit.IDC = 1;
   GCLK->GENCTRL.bit.GENEN = 1;
 


### PR DESCRIPTION
Fixes sketch from @andrewjfox in https://github.com/arduino/ArduinoCore-samd/issues/310#issuecomment-375144902

The divider can have a max resolution of 8-bits since we are using generator 3:

<img width="724" alt="screen shot 2018-03-22 at 3 11 50 pm" src="https://user-images.githubusercontent.com/1163840/37793343-cbc8d5a8-2de4-11e8-915b-ebb334461f76.png">

These changes use the 8 MHz oscillator as the clock source instead of the 48 MHz DFLL if the divider can't fit in 8-bits.