### PR TITLE
Fix USB Host failures

### DIFF
--- a/libraries/USBHost/src/hid.cpp
+++ b/libraries/USBHost/src/hid.cpp
@@ -32,7 +32,7 @@ uint32_t HID::GetReportDescr(uint32_t ep, USBReadParser *parser) {
 }
  */
 uint32_t HID::GetReportDescr(uint32_t wIndex, USBReadParser *parser) {
-        const uint8_t constBufLen = 64;
+        const uint8_t constBufLen = 128;
         uint8_t buf[constBufLen];
 
         uint8_t rcode = pUsb->ctrlReq(bAddress, 0x00, bmREQ_HIDREPORT, USB_REQUEST_GET_DESCRIPTOR, 0x00,

--- a/libraries/USBHost/src/hidboot.h
+++ b/libraries/USBHost/src/hidboot.h
@@ -311,10 +311,6 @@ uint32_t HIDBoot<BOOT_PROTOCOL>::Init(uint32_t parent, uint32_t port, uint32_t l
     }
 
 
-	// Reset
-	//UHD_BusReset();
-	//while( Is_uhd_starting_reset() ) {}
-
 	// Restore p->epinfo
 	p->epinfo = oldep_ptr;
 

--- a/libraries/USBHost/src/hidboot.h
+++ b/libraries/USBHost/src/hidboot.h
@@ -312,8 +312,8 @@ uint32_t HIDBoot<BOOT_PROTOCOL>::Init(uint32_t parent, uint32_t port, uint32_t l
 
 
 	// Reset
-	UHD_BusReset();
-	while( Is_uhd_starting_reset() ) {}
+	//UHD_BusReset();
+	//while( Is_uhd_starting_reset() ) {}
 
 	// Restore p->epinfo
 	p->epinfo = oldep_ptr;


### PR DESCRIPTION
Fix for Issue #342.

Due does not do a Bus Reset before setting the bus address so this matches Due. 

One device sends a HID report descriptor that is more than 64 bytes so increasing the buffer to 128 should cover more devices.