### PR TITLE
Always call new DoubleBufferedEPOutHandler on reconnect

### DIFF
--- a/cores/arduino/USB/SAMD21_USBDevice.h
+++ b/cores/arduino/USB/SAMD21_USBDevice.h
@@ -254,6 +254,11 @@ public:
 		release();
 	}
 
+	~DoubleBufferedEPOutHandler() {
+		free((void*)data0);
+		free((void*)data1);
+	}
+
 	virtual uint32_t recv(void *_data, uint32_t len)
 	{
 		uint8_t *data = reinterpret_cast<uint8_t *>(_data);

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -91,7 +91,7 @@ uint8_t udd_ep_in_cache_buffer[7][64];
 // Some EP are handled using EPHanlders.
 // Possibly all the sparse EP handling subroutines will be
 // converted into reusable EPHandlers in the future.
-static EPHandler *epHandlers[7];
+static EPHandler *epHandlers[7] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 //==================================================================
 
@@ -454,9 +454,10 @@ void USBDeviceClass::initEP(uint32_t ep, uint32_t config)
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0)))
 	{
-		if (epHandlers[ep] == NULL) {
-			epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, 256);
+		if (epHandlers[ep] != NULL) {
+			delete (DoubleBufferedEPOutHandler*)epHandlers[ep];
 		}
+		epHandlers[ep] = new DoubleBufferedEPOutHandler(usbd, ep, 256);
 	}
 	else if (config == (USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0)))
 	{


### PR DESCRIPTION
Avoid memory leak by deleting the buffers; DoubleBufferedEPOutHandler should be refactored (in beta branch) to allow separate "new" and "setup" procedures

Fixes #350