### PR TITLE
Remove the DAC requirement that A0 must be PA02

### DIFF
--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -135,7 +135,8 @@ uint32_t analogRead(uint32_t pin)
 
   pinPeripheral(pin, PIO_ANALOG);
 
-  if (pin == A0) { // Disable DAC, if analogWrite(A0,dval) used previously the DAC is enabled
+  // Disable DAC, if analogWrite() was used previously to enable the DAC
+  if ((g_APinDescription[pin].ulADCChannelNumber == ADC_Channel0) || (g_APinDescription[pin].ulADCChannelNumber == DAC_Channel0)) {
     syncDAC();
     DAC->CTRLA.bit.ENABLE = 0x00; // Disable DAC
     //DAC->CTRLB.bit.EOEN = 0x00; // The DAC output is turned off.
@@ -196,7 +197,7 @@ void analogWrite(uint32_t pin, uint32_t value)
   {
     // DAC handling code
 
-    if (pin != PIN_A0) { // Only 1 DAC on A0 (PA02)
+    if ((pinDesc.ulADCChannelNumber != ADC_Channel0) && (pinDesc.ulADCChannelNumber != DAC_Channel0)) { // Only 1 DAC on AIN0 / PA02
       return;
     }
 


### PR DESCRIPTION
Currently, in order to use the DAC output, each variant must define A0 so that it uses the physical pin PA02. This requirement creates some inflexibly when designing new boards.

This PR removes that requirement allowing for any pin (with PIN_ATTR_ANALOG)  to be used for the DAC output, providing it is defined using the correct ADC channel AIN0. The pin must be described with ADC_Channel0, or optionally with DAC_Channel0. 

Also the DAC_Channel0 definition does not actually seem to be used anywhere in the core except for the additional DAC entry in the pin description array (e.g. entry 43 for the zero or entry 47 for the mzero).  Additionally, those pin entries currently cannot be used as the current analogWrite(pin, value) code will only configure the DAC output if the pin parameter is A0.