### PR TITLE
Added method to return USB Error code.

### DIFF
--- a/libraries/USBHost/src/Usb.cpp
+++ b/libraries/USBHost/src/Usb.cpp
@@ -49,6 +49,10 @@ void USBHost::setUsbTaskState(uint32_t state) {
     usb_task_state = state;
 }
 
+uint32_t USBHost::getUsbErrorCode(void) {
+     return (usb_error);
+}
+ 
 EpInfo* USBHost::getEpInfoEntry(uint32_t addr, uint32_t ep) {
 	UsbDeviceDefinition *p = addrPool.GetUsbDevicePtr(addr);
 

--- a/libraries/USBHost/src/UsbCore.h
+++ b/libraries/USBHost/src/UsbCore.h
@@ -222,7 +222,8 @@ public:
         };
         uint32_t getUsbTaskState(void);
         void setUsbTaskState(uint32_t state);
-
+        uint32_t getUsbErrorCode(void);
+        
         EpInfo* getEpInfoEntry(uint32_t addr, uint32_t ep);
         uint32_t setEpInfoEntry(uint32_t addr, uint32_t epcount, EpInfo* eprecord_ptr);
 


### PR DESCRIPTION
I needed to retrieve the error code from USB tasks. It was being set but there was no method for retrieving it.