### PR TITLE
Add isUARTEnable API

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -108,6 +108,11 @@ void SERCOM::enableUART()
   while(sercom->USART.SYNCBUSY.bit.ENABLE);
 }
 
+bool SERCOM::isUARTEnabled() {
+  // check for Uart Enable state
+  return sercom->USART.CTRLA.bit.ENABLE & SERCOM_USART_CTRLA_ENABLE;
+}
+
 void SERCOM::flushUART()
 {
   // Skip checking transmission completion if data register is empty

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -164,9 +164,10 @@ class SERCOM
 		uint8_t readDataUART( void ) ;
 		int writeDataUART(uint8_t data) ;
 		bool isUARTError() ;
+		bool isUARTEnabled() ;
 		void acknowledgeUARTError() ;
-		void enableDataRegisterEmptyInterruptUART();
-		void disableDataRegisterEmptyInterruptUART();
+		void enableDataRegisterEmptyInterruptUART() ;
+		void disableDataRegisterEmptyInterruptUART() ;
 
 		/* ========== SPI ========== */
 		void initSPI(SercomSpiTXPad mosi, SercomRXPad miso, SercomSpiCharSize charSize, SercomDataOrder dataOrder) ;

--- a/cores/arduino/Uart.cpp
+++ b/cores/arduino/Uart.cpp
@@ -83,6 +83,10 @@ void Uart::end()
 
 void Uart::flush()
 {
+  if (!sercom->isUARTEnabled()) {
+    return;
+  }
+
   while(txBuffer.available()); // wait until TX buffer is empty
 
   sercom->flushUART();


### PR DESCRIPTION
Implemented API for status check: 
- Added API for check the UART status in Uart::flush()
- Added the API in SERCOM.h and SERCOM.cpp
 i have tested  the change with the following sketch:

```c++
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  Serial1.begin(115200);
  Serial1.println("asdasdasdasfasdfafasdasdas_1");
  Serial1.end();
  Serial1.println("asdasfasfasfasfafsafasdfasfsdf_2");
  Serial1.flush();
}
```

without the change it stop in to the first time that flush is called.

cc/ @sandeepmistry @facchinm 