### PR TITLE
fix freeze due to tone()

### DIFF
--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -114,7 +114,7 @@ void tone (uint32_t outputPin, uint32_t frequency, uint32_t duration)
     default: break;
   }
 
-  toggleCount = (duration > 0 ? frequency * duration * 2 / 1000UL : -1);
+  toggleCount = (duration > 0 ? frequency * duration * 2 / 1000UL : -1LL);
 
   resetTC(TONE_TC);
 


### PR DESCRIPTION
In file Tone.cpp added suffix -1LL to the constant in line 117 in order to avoid freeze for instance of tone(pin, 35000);

Resolve https://github.com/arduino/ArduinoCore-samd/issues/360#event-1946355616

cc/ @sandeepmistry tested, the tone() had run for more then two days