### PR TITLE
USBDeviceClass::connected does not reflect actual connection state

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -520,8 +520,8 @@ void USBDeviceClass::stall(uint32_t ep)
 bool USBDeviceClass::connected()
 {
 	// Count frame numbers
-	uint8_t f = USB->DEVICE.FNUM.bit.FNUM;
-	//delay(3);
+	auto f = USB->DEVICE.FNUM.bit.FNUM;
+	delay(3);
 	return f != USB->DEVICE.FNUM.bit.FNUM;
 }
 


### PR DESCRIPTION
Storing `FNUM` in an `uint8_t` would almost always reflect in `f` being different from `FNUM` even if `FNUM` did not change due to the information loss as `FNUM` is of type `uint16_t`.

The delay is required to give it time to change if the device is connected.
Although I'm not sure of the amount of delay required for it to change.

Tested with Arduino MKR WiFi 1010.