### PR TITLE
Bad i2c dev recovery

### DIFF
--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -202,6 +202,8 @@ class SERCOM
 		bool isSlaveWIRE( void ) ;
 		bool isBusIdleWIRE( void ) ;
 		bool isBusOwnerWIRE( void ) ;
+		bool isArbLostWIRE( void );
+		bool isBusBusyWIRE( void );
 		bool isDataReadyWIRE( void ) ;
 		bool isStopDetectedWIRE( void ) ;
 		bool isRestartDetectedWIRE( void ) ;


### PR DESCRIPTION
This fixes the issue I reported [to platformio](https://github.com/platformio/platformio-pkg-framework-arduinosam/issues/9). The downside is that `startTransmissionWIRE()` will immediately return an error on a multi-master I2C bus when another master currently owns the bus. Previous behavior was to wait indefinitely until the other master released the bus.