### PR TITLE
Changed POW_ON pin value on MKR1500's variant

### DIFF
--- a/variants/mkrnb1500/variant.cpp
+++ b/variants/mkrnb1500/variant.cpp
@@ -226,9 +226,9 @@ void initVariant() {
   disable_battery_fet(!batteryPresent);
 #endif
 
-  // enable the POW_ON pin
+  // power off the module
   pinMode(SARA_PWR_ON, OUTPUT);
-  digitalWrite(SARA_PWR_ON, HIGH);
+  digitalWrite(SARA_PWR_ON, LOW);
 
   // put SARA modem in reset on start to conserve power if it's not used
   pinMode(SARA_RESETN, OUTPUT);


### PR DESCRIPTION
Changed POW_ON pin value on MKRNB1500's variant file, to allow the power on from MKRNB library.

cc/ @sandeepmistry as discussed here the change double check