### PR TITLE
Improve Arduino compatibility with the STL (min and max macro)

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -104,9 +104,8 @@ void loop( void ) ;
 #define abs(x) ((x)>0?(x):-(x))
 #define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #else
-	using std::min;
-	using std::max;
-	
+  using std::min;
+  using std::max;
 #endif
 
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -77,6 +77,7 @@ void loop( void ) ;
   #include "WMath.h"
   #include "HardwareSerial.h"
   #include "pulse.h"
+  #include <bits/stl_algobase.h>
 #endif
 #include "delay.h"
 #ifdef __cplusplus
@@ -92,6 +93,7 @@ void loop( void ) ;
 #include "wiring_shift.h"
 #include "WInterrupts.h"
 
+#ifndef __cplusplus
 // undefine stdlib's abs if encountered
 #ifdef abs
 #undef abs
@@ -100,8 +102,14 @@ void loop( void ) ;
 #define min(a,b) ((a)<(b)?(a):(b))
 #define max(a,b) ((a)>(b)?(a):(b))
 #define abs(x) ((x)>0?(x):-(x))
-#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+#else
+	using std::min;
+	using std::max;
+	
+#endif
+
+#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define radians(deg) ((deg)*DEG_TO_RAD)
 #define degrees(rad) ((rad)*RAD_TO_DEG)
 #define sq(x) ((x)*(x))

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -111,7 +111,7 @@ void loop( void ) ;
   }
 
   template<class T, class L> 
-  auto max(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  auto max(const T& a, const L& b) -> decltype((a < b) ? b : a)
   {
     return (a < b) ? b : a;
   }

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -1,14 +1,17 @@
 /*
   Arduino.h - Main include file for the Arduino SDK
   Copyright (c) 2014 Arduino LLC.  All right reserved.
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.
+
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.
+
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -77,7 +77,6 @@ void loop( void ) ;
   #include "WMath.h"
   #include "HardwareSerial.h"
   #include "pulse.h"
-  #include <bits/stl_algobase.h>
 #endif
 #include "delay.h"
 #ifdef __cplusplus

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -1,17 +1,14 @@
 /*
   Arduino.h - Main include file for the Arduino SDK
   Copyright (c) 2014 Arduino LLC.  All right reserved.
-
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.
-
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.
-
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -104,8 +101,17 @@ void loop( void ) ;
 #define abs(x) ((x)>0?(x):-(x))
 #define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #else
-  using std::min;
-  using std::max;
+  template<class T, class L> 
+  auto min(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  {
+    return (b < a) ? b : a;
+  }
+
+  template<class T, class L> 
+  auto max(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  {
+    return (a < b) ? b : a;
+  }
 #endif
 
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))


### PR DESCRIPTION
Replaced the min and max macros with std::min and std::max to allow compilation of bits/stl_algobase.h, a core component of many STL components such as std::function.