### PR TITLE
Fixed an issue with interrupt pins

### DIFF
--- a/variants/circuitplay/variant.cpp
+++ b/variants/circuitplay/variant.cpp
@@ -121,7 +121,7 @@ const PinDescription g_APinDescription[]=
   // Digital Low
   { PORTB,  2, PIO_SERCOM_ALT, 0, ADC_Channel10, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_2 },                                    // GPIO D2 / A5 / SDA
   { PORTB,  3, PIO_SERCOM_ALT, PIN_ATTR_DIGITAL, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_3 },                    // GPIO D3 / A4 / SCL
-  { PORTA, 28, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },                           // GPIO D4 / Left Button
+  { PORTA, 28, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_8 },                              // GPIO D4 / Left Button
   { PORTA, 14, PIO_DIGITAL, (PIN_ATTR_DIGITAL), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_14 },                    // GPIO D5 / Right button
   { PORTA,  5, PIO_TIMER, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), ADC_Channel5, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_5 },   // GPIO D6 / A1
   { PORTA, 15, PIO_TIMER, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), No_ADC_Channel, PWM3_CH1, TC3_CH1, EXTERNAL_INT_15 }, // GPIO D7 / Slide Switch


### PR DESCRIPTION
https://learn.adafruit.com/assets/47156
Fixed the discrepancy between the circuit playground diagram and the code. In the diagram, button A is labelled as an interrupt pin even though the code does not reflect this. This change fixes the issue.