### PR TITLE
Using available defines instead of hardcoded values within USB stack

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -155,7 +155,7 @@ bool Serial_::setup(USBSetup& setup)
 			// auto-reset into the bootloader is triggered when the port, already
 			// open at 1200 bps, is closed. We check DTR state to determine if host 
 			// port is open (bit 0 of lineState).
-			if (_usbLineInfo.dwDTERate == 1200 && (_usbLineInfo.lineState & 0x01) == 0)
+			if (_usbLineInfo.dwDTERate == 1200 && (_usbLineInfo.lineState & CDC_LINESTATE_DTR) == 0)
 			{
 				initiateReset(250);
 			}
@@ -326,11 +326,11 @@ uint8_t Serial_::numbits() {
 }
 
 bool Serial_::dtr() {
-	return _usbLineInfo.lineState & 0x1;
+	return ((_usbLineInfo.lineState & CDC_LINESTATE_DTR) == CDC_LINESTATE_DTR);
 }
 
 bool Serial_::rts() {
-	return _usbLineInfo.lineState & 0x2;
+	return ((_usbLineInfo.lineState & CDC_LINESTATE_RTS) == CDC_LINESTATE_RTS);
 }
 
 Serial_ SerialUSB(USBDevice);


### PR DESCRIPTION
While working on #404 I've noticed that both `CDC_LINESTATE_DTR` and `CDC_LINESTATE_RTS` are defined but on those occasions where this defined value could be used hardcoded values are used instead.

This pull request rectifies this situations.

Sucessfully tested with `MKR VIDOR 4000`.