### PR TITLE
Add RUNSTDBY flag to enable wake on I2C address match

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -413,6 +413,12 @@ void SERCOM::disableWIRE()
   }
 }
 
+void SERCOM::runstandbyWIRE(bool runstdby) {
+  disableWIRE();                                 //  RUNSTDBY bit is enable protected so disable the peripheral
+  sercom->I2CM.CTRLA.bit.RUNSTDBY = runstdby ;
+  enableWIRE();
+}
+
 void SERCOM::initSlaveWIRE( uint8_t ucAddress, bool enableGeneralCall )
 {
   // Initialize the peripheral clock and interruption

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -212,6 +212,7 @@ class SERCOM
     bool isRXNackReceivedWIRE( void ) ;
 		int availableWIRE( void ) ;
 		uint8_t readDataWIRE( void ) ;
+		void runstandbyWIRE( bool ) ;
 
 	private:
 		Sercom* sercom;

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -58,6 +58,10 @@ void TwoWire::setClock(uint32_t baudrate) {
   sercom->enableWIRE();
 }
 
+void TwoWire::standby(bool runstdby) {
+  sercom->runstandbyWIRE(runstdby);
+}
+
 void TwoWire::end() {
   sercom->disableWIRE();
 }

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -37,6 +37,7 @@ class TwoWire : public Stream
     void begin(uint8_t, bool enableGeneralCall = false);
     void end();
     void setClock(uint32_t);
+    void standby(bool runstdby = false);
 
     void beginTransmission(uint8_t);
     uint8_t endTransmission(bool stopBit);


### PR DESCRIPTION
A Wire port can generate an interrupt on address match when sleeping to wake the mcu.  To do so requires that the I2C peripheral is enabled and has the "RUNSTDBY" bit in the CTRLA register set.

The current SAMD core does not have a method to set the RUNSTDBY bit.  This PR adds methods to the Wire and SERCOM libraries to support this.  The peripheral is disabled, the RUNSTDBY bit it configured and the peripheral is enabled again.

The name for the proposed Wire method was selected to be consistent with the only other instance of setting RUNSTDBY I could find which is located in the USBCore. 