### PR TITLE
fix inconsistent type usage between CDC.h and CDC.cpp

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -321,7 +321,7 @@ int32_t Serial_::readBreak() {
 	return ret;
 }
 
-unsigned long Serial_::baud() {
+uint32_t Serial_::baud() {
 	return _usbLineInfo.dwDTERate;
 }
 

--- a/cores/arduino/USB/CDC.h
+++ b/cores/arduino/USB/CDC.h
@@ -82,7 +82,7 @@ public:
 	Serial_(USBDeviceClass &_usb);
 
 	void begin(uint32_t baud_count);
-	void begin(unsigned long, uint8_t);
+	void begin(uint32_t, uint8_t);
 	void end(void);
 
 	virtual int available(void);


### PR DESCRIPTION
Serial_::baud() is prototyped in CDC.h to return uint32_t, but then uses unsigned long in CDC.cpp

A variant of Serial_::begin() is prototyped in CDC.h to accept unsigned long as an argument, but then uses uint32_t in CDC.cpp

This patch standardizes both to use uint32_t.
