### PR TITLE
fix inconsistent type usage between CDC.h and CDC.cpp

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -67,9 +67,9 @@
 class HardwareSerial : public Stream
 {
   public:
-    virtual void begin(unsigned long);
-    virtual void begin(unsigned long baudrate, uint16_t config);
-    virtual void end();
+    virtual void begin(unsigned long) {}
+    virtual void begin(unsigned long baudrate, uint16_t config) {}
+    virtual void end() {}
     virtual int available(void) = 0;
     virtual int peek(void) = 0;
     virtual int read(void) = 0;

--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -191,12 +191,12 @@ void Serial_::enableInterrupt() {
 	usbd.epBank0EnableTransferComplete(CDC_ENDPOINT_OUT);
 }
 
-void Serial_::begin(uint32_t /* baud_count */)
+void Serial_::begin(unsigned long /* baud_count */)
 {
 	// uart config is ignored in USB-CDC
 }
 
-void Serial_::begin(uint32_t /* baud_count */, uint8_t /* config */)
+void Serial_::begin(unsigned long /* baud_count */, uint16_t /* config */)
 {
 	// uart config is ignored in USB-CDC
 }

--- a/cores/arduino/USB/CDC.h
+++ b/cores/arduino/USB/CDC.h
@@ -81,8 +81,8 @@ class Serial_ : public Stream, public PluggableUSBModule {
 public:
 	Serial_(USBDeviceClass &_usb);
 
-	void begin(uint32_t baud_count);
-	void begin(unsigned long, uint8_t);
+	void begin(unsigned long baud_count);
+	void begin(unsigned long, uint16_t);
 	void end(void);
 
 	virtual int available(void);
@@ -118,7 +118,7 @@ public:
 	// These return the settings specified by the USB host for the
 	// serial port. These aren't really used, but are offered here
 	// in case a sketch wants to act on these settings.
-	uint32_t baud();
+	unsigned long baud();
 	uint8_t stopbits();
 	uint8_t paritytype();
 	uint8_t numbits();


### PR DESCRIPTION
Serial_::baud() is prototyped in CDC.h to return uint32_t, but then uses unsigned long in CDC.cpp

A variant of Serial_::begin() is prototyped in CDC.h to accept unsigned long as an argument, but then uses uint32_t in CDC.cpp

Judging by other code such as Uart.cpp/Uart.h, I'm inferring that the de facto standard is to treat the bit rate as type "unsigned long", rather than "uint32_t".  So, this patch fixes usage to be consistent.  Similarly, the second argument to ::begin() is changed to uint16_t to be consistent with Uart.cpp/Uart.h.
