### PR TITLE
base empty implementation for non-pure virtual functions in HardwareSerial.h

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -67,9 +67,9 @@
 class HardwareSerial : public Stream
 {
   public:
-    virtual void begin(unsigned long);
-    virtual void begin(unsigned long baudrate, uint16_t config);
-    virtual void end();
+    virtual void begin(unsigned long) {}
+    virtual void begin(unsigned long baudrate, uint16_t config) {}
+    virtual void end() {}
     virtual int available(void) = 0;
     virtual int peek(void) = 0;
     virtual int read(void) = 0;


### PR DESCRIPTION
Although the GCC 7-2017Q4 presently bundled into the Arduino SAMD v1.8.3 package doesn't complain, more recent compiler versions are not as accommodating.  What I've seeing with GCC 8-2018Q4 is:

Uart.o: in function 'HardwareSerial::HardwareSerial()': undefined reference to 'vtable for HardwareSerial'

The Uart class is derived from HardwareSerial, and the compiler error is due to begin() and end() not being pure virtual and not having a base class implementation.

I see two options.  One would be to declare begin() and end() as pure virtual (as everything declared in HardwareSerial is).  However, I *presume* there is some latent reasoning by the author to exclude those particular declarations.  If we change this, there also seems to be the possibility of breaking someone's code.

The second option would be to provide a base empty implementation for these functions.  This satisfies the compiler's need to have a default implementation should the derived classes not implement one.
