### PR TITLE
Add null pointer test to String destructor

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -123,7 +123,7 @@ String::String(double value, unsigned char decimalPlaces)
 
 String::~String()
 {
-	free(buffer);
+	if (buffer) free(buffer);
 }
 
 /*********************************************/


### PR DESCRIPTION
A rare but possible null pointer dereference occurs when a String object is destroyed after either a failed initialization or intentional invalidation. Adding a simple `if (buffer)` test before `free`ing it avoids this failure case.