### PR TITLE
Add virtual base for method "ready" in Client

### DIFF
--- a/cores/arduino/Client.h
+++ b/cores/arduino/Client.h
@@ -37,6 +37,7 @@ public:
   virtual void flush() = 0;
   virtual void stop() = 0;
   virtual uint8_t connected() = 0;
+  virtual int ready() { return 1; }
   virtual operator bool() = 0;
 protected:
   uint8_t* rawIPAddress(IPAddress& addr) { return addr.raw_address(); };


### PR DESCRIPTION
Hello everyone,

I'm shooting in the dark as of what could imply this but, what about adding the virtual base for "ready" method in Client class?
I've tested it and works seamlessly with my current code, meanwhile it allows for polymorphic abstraction when building a class that should work asynchronously with all the possible clients (GPRS, WiFi, etc.) polimorphically.

The "ready()" method is mandatory when working asynchronously (a great feature when dealing with whatchdog), but Client base class lacks its declaration. Because of this one should wrap the whole in a class just to add the "ready" method, or reimplement over and over almost the same code for every possible transport. Having the base instead would allow one to define the asynch code once for all.

I added a default body instead of making it pure virtual just to don't oblige to implement it even where not required (ie. MqttClient complained about this).

Again, I don't know if this clashes with your class tree logic, but I believe it would be seamless and yet useful when working through advanced c++ ways (so not for normal use).