### PR TITLE
Implement SERCOM/Wire I2C timeout detection

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -29,6 +29,8 @@
 SERCOM::SERCOM(Sercom* s)
 {
   sercom = s;
+  timeoutOccurred = false;
+  timeoutInterval = SERCOM_DEFAULT_I2C_OPERATION_TIMEOUT_MS;
 }
 
 /* 	=========================
@@ -517,9 +519,10 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
   sercom->I2CM.ADDR.bit.ADDR = address;
 
   // Address Transmitted
+  initTimeout();
   if ( flag == WIRE_WRITE_FLAG ) // Write mode
   {
-    while( !sercom->I2CM.INTFLAG.bit.MB )
+    while( !sercom->I2CM.INTFLAG.bit.MB && !testTimeout() )
     {
       // Wait transmission complete
     }
@@ -532,7 +535,7 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
   }
   else  // Read mode
   {
-    while( !sercom->I2CM.INTFLAG.bit.SB )
+    while( !sercom->I2CM.INTFLAG.bit.SB && !testTimeout() )
     {
         // If the slave NACKS the address, the MB bit will be set.
         // In that case, send a stop condition and return false.
@@ -547,6 +550,8 @@ bool SERCOM::startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag
     //sercom->I2CM.INTFLAG.bit.SB = 0x1ul;
   }
 
+  // check for timeout condition
+  if ( didTimeout() ) return false;
 
   //ACK received (0: ACK, 1: NACK)
   if(sercom->I2CM.STATUS.bit.RXNACK)
@@ -565,7 +570,8 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
   sercom->I2CM.DATA.bit.DATA = data;
 
   //Wait transmission successful
-  while(!sercom->I2CM.INTFLAG.bit.MB) {
+  initTimeout();
+  while(!sercom->I2CM.INTFLAG.bit.MB && !testTimeout()) {
 
     // If a bus error occurs, the MB bit may never be set.
     // Check the bus error bit and bail if it's set.
@@ -573,6 +579,9 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
       return false;
     }
   }
+
+  // check for timeout condition
+  if ( didTimeout() ) return false;
 
   //Problems on line? nack received?
   if(sercom->I2CM.STATUS.bit.RXNACK)
@@ -665,7 +674,8 @@ uint8_t SERCOM::readDataWIRE( void )
 {
   if(isMasterWIRE())
   {
-    while( sercom->I2CM.INTFLAG.bit.SB == 0 && sercom->I2CM.INTFLAG.bit.MB == 0 )
+    initTimeout();
+    while( sercom->I2CM.INTFLAG.bit.SB == 0 && sercom->I2CM.INTFLAG.bit.MB == 0 && !testTimeout() )
     {
       // Waiting complete receive
     }
@@ -738,4 +748,27 @@ void SERCOM::initClockNVIC( void )
   {
     /* Wait for synchronization */
   }
+}
+
+void SERCOM::setTimeout( uint16_t ms )
+{
+  timeoutInterval = ms;
+}
+
+bool SERCOM::didTimeout( void )
+{
+  return timeoutOccurred;
+}
+
+void SERCOM::initTimeout( void )
+{
+  timeoutOccurred = false;
+  timeoutRef = millis();
+}
+
+bool SERCOM::testTimeout( void )
+{
+  if (!timeoutInterval) return false;
+  timeoutOccurred = (millis() - timeoutRef) > timeoutInterval;
+  return timeoutOccurred;
 }

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -24,6 +24,9 @@
 #define SERCOM_FREQ_REF      48000000
 #define SERCOM_NVIC_PRIORITY ((1<<__NVIC_PRIO_BITS) - 1)
 
+// timeout detection default length (zero is disabled)
+#define SERCOM_DEFAULT_I2C_OPERATION_TIMEOUT_MS 1000
+
 typedef enum
 {
 	UART_EXT_CLOCK = 0,
@@ -212,12 +215,21 @@ class SERCOM
     bool isRXNackReceivedWIRE( void ) ;
 		int availableWIRE( void ) ;
 		uint8_t readDataWIRE( void ) ;
+		void setTimeout( uint16_t ms );
+		bool didTimeout( void );
 
 	private:
 		Sercom* sercom;
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate) ;
 		uint32_t division(uint32_t dividend, uint32_t divisor) ;
 		void initClockNVIC( void ) ;
+
+		// timeout detection for I2C operations
+		void initTimeout( void );
+		bool testTimeout( void );
+		uint16_t timeoutInterval;
+		uint32_t timeoutRef;
+		bool timeoutOccurred;
 };
 
 #endif

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -29,6 +29,9 @@
  // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
+ // WIRE_HAS_TIMEOUT means Wire implements timeout detection
+#define WIRE_HAS_TIMEOUT 1
+
 class TwoWire : public Stream
 {
   public:
@@ -44,6 +47,9 @@ class TwoWire : public Stream
 
     uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
     uint8_t requestFrom(uint8_t address, size_t quantity);
+    
+    bool didTimeout() { return sercom->didTimeout(); }
+    bool setTimeout(uint16_t ms) { sercom->setTimeout(ms); }
 
     size_t write(uint8_t data);
     size_t write(const uint8_t * data, size_t quantity);
@@ -69,6 +75,9 @@ class TwoWire : public Stream
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
+
+    // Used to re-initialize the clock rate after a timeout
+    uint32_t activeBaudrate;
 
     // RX Buffer
     RingBufferN<256> rxBuffer;


### PR DESCRIPTION
This small set of modifications adds basic I2C timeout detection to `Wire` and `SERCOM` on the SAMD platform.

The blocking nature of the standard Wire library on most Arduino platforms has been a huge headache for many people, myself included. The challenge is that the Wire library itself isn't to blame, but rather the underlying layer of platform-specific code (`SERCOM` in the case of the SAMD platform, `twi` for AVR, etc.). You can't rely on the `Stream` class timeout functionality since the hardware layer is separate. To solve this, both `SERCOM` and `Wire` require modifications.

This implementation works as follows:

- Timeouts are detected in the SERCOM layer with a flexible `initTimeout()` and `testTimeout()` method pair. `initTimeout()` is called immediately before a previously blocking loop starts, and `testTimeout()` is called repeatedly as part of the continuing condition for the loop.
- If a timeout occurs, the I2C bus is reset and re-initialized at the previously configured clock rate.
- The timeout init/test functionality is accomplished via `millis()`, which has certain drawbacks (e.g. interrupts required), but given the CPU execution state when Wire/SERCOM blocks during an I2C transaction, these drawbacks are irrelevant. Switching to a simpler implementation like a volatile int accumulator is not hard, but would be less precise.
- The modified `Wire` library exposes the "passthrough" methods `setTimeout(...)` and `didTimeout()` for applying a new timeout value and checking whether a timeout occurred at the SERCOM layer, since SERCOM familiarity is not expected for most users.
- The default timeout value is set to 1000 ms (1 second). A value of 0 disables timeout detection (current behavior, before this fix). Whether this is a safe value or not is up to others; in my experience, it is *far* longer than anyone should ever have to wait assuming a properly behaving I2C peripheral. However, I readily admit that some devices may implement ridiculous clock stretching or something else that make 1000 ms unsafe. I chose this value since it's also the default for the `Stream` class.
- The `beginTransmission()` method has a new return value of `4` to indicate that a timeout occurred. Although this value was previously noted in the comments as "Other error", I found no instances of this in the code.
- Regardless of the previous point, the recommended method for checking for a timeout is to use `Wire.didTimeout()` right after any relevant calls.

As you can see, this implementation doesn't change `Wire` (or `SERCOM`) into a true non-blocking library in the event-driven sense, but it does provide a much-needed easy way to break out of "frozen I2C jail" that the current official core/library doesn't have.