### PR TITLE
Fix requestFrom() return type for 16-bit lengths

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -64,7 +64,7 @@ void TwoWire::end() {
   sercom->disableWIRE();
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 {
   if(quantity == 0)
   {
@@ -105,7 +105,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
   return byteRead;
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity)
+size_t TwoWire::requestFrom(uint8_t address, size_t quantity)
 {
   return requestFrom(address, quantity, true);
 }
@@ -336,4 +336,3 @@ void TwoWire::onService(void)
     Wire5.onService();
   }
 #endif
-

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -45,8 +45,8 @@ class TwoWire : public HardwareI2C
     uint8_t endTransmission(bool stopBit);
     uint8_t endTransmission(void);
 
-    uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
-    uint8_t requestFrom(uint8_t address, size_t quantity);
+    size_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
+    size_t requestFrom(uint8_t address, size_t quantity);
 
     size_t write(uint8_t data);
     size_t write(const uint8_t * data, size_t quantity);


### PR DESCRIPTION
The latest changes to the SAMD core create a 256-byte templated ring buffer for received data in the `Wire` class. However, the `requestFrom` methods only support a `uint8_t` return type, which means they report `0` for the number of bytes received after a 256-byte request (I found this out the hard way). This fix changes `uint8_t` to `size_t` to match the `quantity` argument data type and the `byteRead` variable data type, which is the one actually used to provide the return value.