### PR TITLE
fix charging safety timer issue

### DIFF
--- a/variants/mkrgsm1400/variant.cpp
+++ b/variants/mkrgsm1400/variant.cpp
@@ -182,10 +182,24 @@ SERCOM sercom5(SERCOM5);
 #include "wiring_private.h"
 
 #define PMIC_ADDRESS  0x6B
+#define PMIC_REG00    0x00
 #define PMIC_REG01    0x01
+#define PMIC_REG05    0x05
 #define PMIC_REG07    0x07
 
-#define PMIC_REG00    0x00
+static inline void disable_charging_safety_timer() {
+  PERIPH_WIRE.initMasterWIRE(100000);
+  PERIPH_WIRE.enableWIRE();
+  pinPeripheral(PIN_WIRE_SDA, g_APinDescription[PIN_WIRE_SDA].ulPinType);
+  pinPeripheral(PIN_WIRE_SCL, g_APinDescription[PIN_WIRE_SCL].ulPinType);
+
+  PERIPH_WIRE.startTransmissionWIRE( PMIC_ADDRESS, WIRE_WRITE_FLAG );
+  PERIPH_WIRE.sendDataMasterWIRE(PMIC_REG05);
+  PERIPH_WIRE.sendDataMasterWIRE(0x82);  //disable chargin safety timer
+  PERIPH_WIRE.prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+
+  PERIPH_WIRE.disableWIRE();
+}
 
 static inline void set_voltage_current_thresholds() {
   PERIPH_WIRE.initMasterWIRE(100000);
@@ -247,6 +261,7 @@ void initVariant() {
   }
   disable_battery_fet(!batteryPresent);
   set_voltage_current_thresholds();
+  disable_charging_safety_timer();
 #endif
 
   // put GSM modem in reset on start to conserve power if it's not used

--- a/variants/mkrnb1500/variant.cpp
+++ b/variants/mkrnb1500/variant.cpp
@@ -184,7 +184,22 @@ SERCOM sercom5(SERCOM5);
 #define PMIC_ADDRESS  0x6B
 #define PMIC_REG00    0x00
 #define PMIC_REG01    0x01
+#define PMIC_REG05    0x05
 #define PMIC_REG07    0x07
+
+static inline void disable_charging_safety_timer() {
+  PERIPH_WIRE.initMasterWIRE(100000);
+  PERIPH_WIRE.enableWIRE();
+  pinPeripheral(PIN_WIRE_SDA, g_APinDescription[PIN_WIRE_SDA].ulPinType);
+  pinPeripheral(PIN_WIRE_SCL, g_APinDescription[PIN_WIRE_SCL].ulPinType);
+
+  PERIPH_WIRE.startTransmissionWIRE( PMIC_ADDRESS, WIRE_WRITE_FLAG );
+  PERIPH_WIRE.sendDataMasterWIRE(PMIC_REG05);
+  PERIPH_WIRE.sendDataMasterWIRE(0x82);  //disable chargin safety timer
+  PERIPH_WIRE.prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+
+  PERIPH_WIRE.disableWIRE();
+}
 
 static inline void enable_battery_charging() {
   PERIPH_WIRE.initMasterWIRE(100000);
@@ -246,6 +261,7 @@ void initVariant() {
   }
   disable_battery_fet(!batteryPresent);
   set_voltage_current_thresholds();
+  disable_charging_safety_timer()
 #endif
 
   // power off the module

--- a/variants/mkrwan1300/variant.cpp
+++ b/variants/mkrwan1300/variant.cpp
@@ -176,8 +176,23 @@ const void* g_apTCInstances[TCC_INST_NUM + TC_INST_NUM]={ TCC0, TCC1, TCC2, TC3,
 
 #define PMIC_ADDRESS  0x6B
 #define PMIC_REG01    0x01
+#define PMIC_REG05    0x05
 #define PMIC_REG07    0x07
 #define PMIC_REG08    0x08
+
+static inline void disable_charging_safety_timer() {
+  PERIPH_WIRE.initMasterWIRE(100000);
+  PERIPH_WIRE.enableWIRE();
+  pinPeripheral(PIN_WIRE_SDA, g_APinDescription[PIN_WIRE_SDA].ulPinType);
+  pinPeripheral(PIN_WIRE_SCL, g_APinDescription[PIN_WIRE_SCL].ulPinType);
+
+  PERIPH_WIRE.startTransmissionWIRE( PMIC_ADDRESS, WIRE_WRITE_FLAG );
+  PERIPH_WIRE.sendDataMasterWIRE(PMIC_REG05);
+  PERIPH_WIRE.sendDataMasterWIRE(0x82);  //disable chargin safety timer
+  PERIPH_WIRE.prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+
+  PERIPH_WIRE.disableWIRE();
+}
 
 static inline void enable_battery_charging() {
 
@@ -241,6 +256,7 @@ void initVariant() {
 
   enable_battery_charging();
   //disable_battery_fet(false);
+  disable_charging_safety_timer();
   delay(100);
   bool batteryPresent = is_battery_present();
   if (!batteryPresent) {

--- a/variants/mkrwifi1010/variant.cpp
+++ b/variants/mkrwifi1010/variant.cpp
@@ -183,7 +183,23 @@ SERCOM sercom5(SERCOM5);
 
 #define PMIC_ADDRESS  0x6B
 #define PMIC_REG01    0x01
+#define PMIC_REG05    0x05
 #define PMIC_REG07    0x07
+
+static inline void disable_charging_safety_timer() {
+  PERIPH_WIRE.initMasterWIRE(100000);
+  PERIPH_WIRE.enableWIRE();
+  pinPeripheral(PIN_WIRE_SDA, g_APinDescription[PIN_WIRE_SDA].ulPinType);
+  pinPeripheral(PIN_WIRE_SCL, g_APinDescription[PIN_WIRE_SCL].ulPinType);
+
+  PERIPH_WIRE.startTransmissionWIRE( PMIC_ADDRESS, WIRE_WRITE_FLAG );
+  PERIPH_WIRE.sendDataMasterWIRE(PMIC_REG05);
+  PERIPH_WIRE.sendDataMasterWIRE(0x82);  //disable chargin safety timer
+  PERIPH_WIRE.prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+
+  PERIPH_WIRE.disableWIRE();
+}
+
 
 static inline void enable_battery_charging() {
   PERIPH_WIRE.initMasterWIRE(100000);
@@ -230,6 +246,7 @@ void initVariant() {
     enable_battery_charging();
   }
   disable_battery_fet(!batteryPresent);
+  disable_charging_safety_timer();
 #endif
 
   // NINA - SPI boot


### PR DESCRIPTION
This changes allow to avoid freeze module's freeze due to fault for charging safety timer expiration for boards where bq24195 is used.

cc/ @sandeepmistry @facchinm the test still running after 22 hours, wait another day or two in order to see if others faults are raised and after we could merge