### PR TITLE
Added printf to Print class to have Serial.printf() functionality

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -183,6 +183,16 @@ size_t Print::println(const Printable& x)
   return n;
 }
 
+void Print::printf(const char format[], ...)
+{
+  char buf[PRINTF_BUF];
+  va_list ap;
+  va_start(ap, format);
+  vsnprintf(buf, sizeof(buf), format, ap);
+  write(buf);
+  va_end(ap);
+}
+
 // Private Methods /////////////////////////////////////////////////////////////
 
 size_t Print::printNumber(unsigned long n, uint8_t base)

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -21,6 +21,8 @@
 
 #include <inttypes.h>
 #include <stdio.h> // for size_t
+#include <stdarg.h> // for printf
+#define PRINTF_BUF 80
 
 #include "WString.h"
 #include "Printable.h"
@@ -85,6 +87,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    void printf(const char[], ...);
 
     virtual void flush() { /* Empty implementation for backward compatibility */ }
 };


### PR DESCRIPTION
Adafruits version of the SAMD Arduino framework has Print::printf function. As the SAMD MCUs are not as memory limited than the AVR 8 bit MCUs I think it will not hurt to add it.