### PR TITLE
Update I2S.cpp WDT patch

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -419,6 +419,7 @@ void I2SClass::enableClock(int divider)
 
   // use the DFLL as the source
   while (GCLK->STATUS.bit.SYNCBUSY);
+  GCLK->GENCTRL.bit.DIVSEL = 0;
   GCLK->GENCTRL.bit.ID = _clockGenerator;
   GCLK->GENCTRL.bit.SRC = src;
   GCLK->GENCTRL.bit.IDC = 1;


### PR DESCRIPTION
enableClock() in I2S.cpp does not set DIVSEL bit but requires DIVSEL to be 0.
All of the WDT's i have tested so far set DIVSEL to 1.
This leads to incompatibilities. For example no sound with ArduinoSound and WDT