### PR TITLE
fix example to support nano_33_iot

### DIFF
--- a/libraries/I2S/examples/InputSerialPlotter/InputSerialPlotter.ino
+++ b/libraries/I2S/examples/InputSerialPlotter/InputSerialPlotter.ino
@@ -5,13 +5,13 @@
  data (Tools -> Serial Plotter)
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
+ * Arduino/Genuino Zero, MKR family and Nano 33 IoT
  * ICS43432:
    * GND connected GND
-   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKRZero)
-   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * 3.3V connected to 3.3V (Zero, Nano) or VCC (MKR)
+   * WS connected to pin 0 (Zero) or 3 (MKR) or A2 (Nano)
+   * CLK connected to pin 1 (Zero) or 2 (MKR) or A3 (Nano)
+   * SD connected to pin 9 (Zero) or A6 (MKR) or 4 (Nano)
 
  created 17 November 2016
  by Sandeep Mistry

--- a/libraries/I2S/examples/SimpleTone/SimpleTone.ino
+++ b/libraries/I2S/examples/SimpleTone/SimpleTone.ino
@@ -4,13 +4,13 @@
  MAX08357 I2S Amp Breakout board.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
+ * Arduino/Genuino Zero, MKR family and Nano 33 IoT
  * MAX08357:
    * GND connected GND
    * VIN connected 5V
-   * LRC connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * BCLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * DIN connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * LRC connected to pin 0 (Zero) or 3 (MKR) or A2 (Nano)
+   * BCLK connected to pin 1 (Zero) or 2 (MKR) or A3 (Nano)
+   * DIN connected to pin 9 (Zero) or A6 (MKR) or 4 (Nano)
 
  created 17 November 2016
  by Sandeep Mistry


### PR DESCRIPTION
I made this PR simply to fix the examples circuit (which were outdated).
Linked PR: https://github.com/arduino-libraries/ArduinoSound/pull/20
The I2S Library will work on the nano 33 iot only when https://github.com/arduino/ArduinoCore-samd/pull/471 will be part of the updated core.