### PR TITLE
Improve EIC_Hander to control when the interrupt is cleared

### DIFF
--- a/cores/arduino/WInterrupts.h
+++ b/cores/arduino/WInterrupts.h
@@ -46,6 +46,11 @@ void attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode);
  * \brief Turns off the given interrupt.
  */
 void detachInterrupt(uint32_t pin);
+  
+/*
+ * \brief Clears the current interrup. This intended to be used only inside the ISR.
+ */
+void clearInterrupt();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I find the way `EIC_Handler` clears interrupt impractical. I have a use case (see below) where I want to clear the interrupt before executing the callback. Therefore I modified `Winterrupts.c` to allow manually clearing the interrupt earlier from the ISR.

My use case: I want to make sure that the value I read from the pin is eventually correct (after the pin voltage has become stable). If the interrupt is not enabled when I do the digitalRead, I may miss a state change.

I don't know if this integrates well with the general idea of this library (and other boards') and I'd appreciate to have feedback on that.