### PR TITLE
Fix flash size regex and add RAM size regex

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -117,7 +117,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.{build.preferred_ou
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=\.text\s+([0-9]+).*
+recipe.size.regex=^(?:\.text|\.data|)\s+([0-9]+).*
 
 # Upload/Debug tools
 # ------------------

--- a/platform.txt
+++ b/platform.txt
@@ -118,6 +118,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.{build.preferred_ou
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
 recipe.size.regex=^(?:\.text|\.data|)\s+([0-9]+).*
+recipe.size.regex.data=^(?:\.data|\.bss)\s+([0-9]+).*
 
 # Upload/Debug tools
 # ------------------


### PR DESCRIPTION
This fixes the size regex to include intitialized variables (`.data` section) and adds a data/RAM size regex, allowing the RAM usage to be displayed.