### PR TITLE
Add debug recipe configurable interpreter flag

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -20,7 +20,7 @@ arduino_zero_edbg.name=Arduino Zero (Programming Port)
 arduino_zero_edbg.vid.0=0x03eb
 arduino_zero_edbg.pid.0=0x2157
 
-arduino_zero_edbg.debug.tool=gdb
+arduino_zero_edbg.debug.tool=gdb-openocd
 arduino_zero_edbg.upload.tool=openocd
 arduino_zero_edbg.upload.protocol=sam-ba
 arduino_zero_edbg.upload.maximum_size=262144
@@ -89,7 +89,7 @@ mkr1000.pid.2=0x824e
 mkr1000.vid.3=0x2341
 mkr1000.pid.3=0x024e
 
-mkr1000.debug.tool=gdb
+mkr1000.debug.tool=gdb-openocd
 mkr1000.upload.tool=bossac
 mkr1000.upload.protocol=sam-ba
 mkr1000.upload.maximum_size=262144
@@ -119,7 +119,7 @@ mkrzero.pid.0=0x804f
 mkrzero.vid.1=0x2341
 mkrzero.pid.1=0x004f
 
-mkrzero.debug.tool=gdb
+mkrzero.debug.tool=gdb-openocd
 mkrzero.upload.tool=bossac
 mkrzero.upload.protocol=sam-ba
 mkrzero.upload.maximum_size=262144
@@ -149,7 +149,7 @@ mkrwifi1010.pid.0=0x8054
 mkrwifi1010.vid.1=0x2341
 mkrwifi1010.pid.1=0x0054
 
-mkrwifi1010.debug.tool=gdb
+mkrwifi1010.debug.tool=gdb-openocd
 mkrwifi1010.upload.tool=bossac
 mkrwifi1010.upload.protocol=sam-ba
 mkrwifi1010.upload.maximum_size=262144
@@ -179,7 +179,7 @@ nano_33_iot.pid.0=0x8057
 nano_33_iot.vid.1=0x2341
 nano_33_iot.pid.1=0x0057
 
-nano_33_iot.debug.tool=gdb
+nano_33_iot.debug.tool=gdb-openocd
 nano_33_iot.upload.tool=bossac
 nano_33_iot.upload.protocol=sam-ba
 nano_33_iot.upload.maximum_size=262144
@@ -209,7 +209,7 @@ mkrfox1200.pid.0=0x8050
 mkrfox1200.vid.1=0x2341
 mkrfox1200.pid.1=0x0050
 
-mkrfox1200.debug.tool=gdb
+mkrfox1200.debug.tool=gdb-openocd
 mkrfox1200.upload.tool=bossac
 mkrfox1200.upload.protocol=sam-ba
 mkrfox1200.upload.maximum_size=262144
@@ -239,7 +239,7 @@ mkrwan1300.pid.0=0x8053
 mkrwan1300.vid.1=0x2341
 mkrwan1300.pid.1=0x0053
 
-mkrwan1300.debug.tool=gdb
+mkrwan1300.debug.tool=gdb-openocd
 mkrwan1300.upload.tool=bossac
 mkrwan1300.upload.protocol=sam-ba
 mkrwan1300.upload.maximum_size=262144
@@ -269,7 +269,7 @@ mkrwan1310.pid.0=0x8059
 mkrwan1310.vid.1=0x2341
 mkrwan1310.pid.1=0x0059
 
-mkrwan1310.debug.tool=gdb
+mkrwan1310.debug.tool=gdb-openocd
 mkrwan1310.upload.tool=bossac
 mkrwan1310.upload.protocol=sam-ba
 mkrwan1310.upload.maximum_size=262144
@@ -299,7 +299,7 @@ mkrgsm1400.pid.0=0x8052
 mkrgsm1400.vid.1=0x2341
 mkrgsm1400.pid.1=0x0052
 
-mkrgsm1400.debug.tool=gdb
+mkrgsm1400.debug.tool=gdb-openocd
 mkrgsm1400.upload.tool=bossac
 mkrgsm1400.upload.protocol=sam-ba
 mkrgsm1400.upload.maximum_size=262144
@@ -329,7 +329,7 @@ mkrnb1500.pid.0=0x8055
 mkrnb1500.vid.1=0x2341
 mkrnb1500.pid.1=0x0055
 
-mkrnb1500.debug.tool=gdb
+mkrnb1500.debug.tool=gdb-openocd
 mkrnb1500.upload.tool=bossac
 mkrnb1500.upload.protocol=sam-ba
 mkrnb1500.upload.maximum_size=262144
@@ -359,7 +359,7 @@ mkrvidor4000.pid.0=0x8056
 mkrvidor4000.vid.1=0x2341
 mkrvidor4000.pid.1=0x0056
 
-mkrvidor4000.debug.tool=gdb
+mkrvidor4000.debug.tool=gdb-openocd
 mkrvidor4000.upload.tool=bossacI
 mkrvidor4000.upload.protocol=sam-ba
 mkrvidor4000.upload.maximum_size=262144

--- a/platform.txt
+++ b/platform.txt
@@ -236,4 +236,4 @@ tools.openocd-withbootsize.bootloader.pattern="{path}/{cmd}" {bootloader.verbose
 tools.gdb.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
 tools.gdb.cmd=arm-none-eabi-gdb
 tools.gdb.cmd.windows=arm-none-eabi-gdb.exe
-tools.gdb.debug.pattern="{path}/{cmd}" --interpreter=mi2 -ex "set pagination off" -ex 'target extended-remote | {tools.openocd.path}/{tools.openocd.cmd} -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' {build.path}/{build.project_name}.elf
+tools.gdb.debug.pattern="{path}/{cmd}" --interpreter=mi2 -ex "set remotetimeout 5" -ex "set pagination off" -ex 'target extended-remote | "{tools.openocd.path}/{tools.openocd.cmd}" -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' "{build.path}/{build.project_name}.elf"

--- a/platform.txt
+++ b/platform.txt
@@ -236,4 +236,4 @@ tools.openocd-withbootsize.bootloader.pattern="{path}/{cmd}" {bootloader.verbose
 tools.gdb.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
 tools.gdb.cmd=arm-none-eabi-gdb
 tools.gdb.cmd.windows=arm-none-eabi-gdb.exe
-tools.gdb.debug.pattern="{path}/{cmd}" --interpreter=mi2 -ex "set remotetimeout 5" -ex "set pagination off" -ex 'target extended-remote | "{tools.openocd.path}/{tools.openocd.cmd}" -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' "{build.path}/{build.project_name}.elf"
+tools.gdb.debug.pattern="{path}/{cmd}" --interpreter={interpreter} -ex "set remotetimeout 5" -ex "set pagination off" -ex 'target extended-remote | "{tools.openocd.path}/{tools.openocd.cmd}" -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' "{build.path}/{build.project_name}.elf"

--- a/platform.txt
+++ b/platform.txt
@@ -232,8 +232,8 @@ tools.openocd-withbootsize.bootloader.pattern="{path}/{cmd}" {bootloader.verbose
 #
 # EXPERIMENTAL feature: debug.pattern
 #  - this is alpha and may be subject to change without notice
-
-tools.gdb.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
-tools.gdb.cmd=arm-none-eabi-gdb
-tools.gdb.cmd.windows=arm-none-eabi-gdb.exe
-tools.gdb.debug.pattern="{path}/{cmd}" --interpreter={interpreter} -ex "set remotetimeout 5" -ex "set pagination off" -ex 'target extended-remote | "{tools.openocd.path}/{tools.openocd.cmd}" -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' "{build.path}/{build.project_name}.elf"
+tools.gdb-openocd.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
+tools.gdb-openocd.cmd=arm-none-eabi-gdb
+tools.gdb-openocd.cmd.windows=arm-none-eabi-gdb.exe
+tools.gdb-openocd.interpreter=console
+tools.gdb-openocd.debug.pattern="{path}/{cmd}" --interpreter={interpreter} -ex "set remotetimeout 5" -ex "set pagination off" -ex 'target extended-remote | "{tools.openocd.path}/{tools.openocd.cmd}" -s "{tools.openocd.path}/share/openocd/scripts/" --file "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "gdb_port pipe" -c "telnet_port 0"' "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
This PR:

- Adds small fixes to the debug string
- Adds a configurable `{interpreter}` flag to allow switching to machine friendly `mi*` commands or human friendly `console` commands