### PR TITLE
Update clockout comments, add synchronization spin

### DIFF
--- a/variants/mkrvidor4000/clockout.c
+++ b/variants/mkrvidor4000/clockout.c
@@ -5,7 +5,7 @@ void clockout(uint32_t gclk, int32_t divisor)
     GCLK_GENDIV_Type gendiv =
     {
         .bit.DIV = divisor,      // divider, linear or 2^(.DIV+1)
-        .bit.ID  = gclk,         // GCLK_GENERATOR_X
+        .bit.ID  = gclk,         // GCLK_GENERATOR_"gclk"
     };
     GCLK->GENDIV.reg = gendiv.reg;
 
@@ -14,15 +14,17 @@ void clockout(uint32_t gclk, int32_t divisor)
     {
         .bit.RUNSTDBY = 0,        // Run in Standby
         .bit.DIVSEL = 0,          // .DIV (above) Selection: 0=linear 1=powers of 2
-        .bit.OE = 1,              // Output Enable to observe on a port pin
+        .bit.OE = 1,              // Output Enable to observe on any port pin capable of outputting GCLK_IO["gclk"]
         .bit.OOV = 0,             // Output Off Value
         .bit.IDC = 1,             // Improve Duty Cycle
         .bit.GENEN = 1,           // enable this GCLK
-        // select GCLK source
         //.bit.SRC = GCLK_SOURCE_OSC8M,
-        .bit.SRC = GCLK_SOURCE_DFLL48M,
-        // select GCLK2 to output on
-        .bit.ID = gclk,           // GCLK_GENERATOR_X
+        .bit.SRC = GCLK_SOURCE_DFLL48M, // select GCLK source
+        .bit.ID = gclk,           // output GCLK_GENERATOR_"gclk" on GCLK_IO["gclk"]
     };
     GCLK->GENCTRL.reg = genctrl.reg;
+    while ( GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY )
+    {
+        /* Wait for synchronization */
+    }
 }


### PR DESCRIPTION
I've updated the comments here to refer to "gclk" instead of generator x. Also added a spin to wait for the write to clear, just like what's done in `startup.c`.