### PR TITLE
Set USB SRAM QoS to sensitive latency

### DIFF
--- a/cores/arduino/USB/SAMD21_USBDevice.h
+++ b/cores/arduino/USB/SAMD21_USBDevice.h
@@ -50,6 +50,10 @@ public:
 	inline void noRunInStandby() { usb.CTRLA.bit.RUNSTDBY = 0; }
 	inline void wakeupHost()     { usb.CTRLB.bit.UPRSM = 1; }
 
+	// USB QoS
+	inline void setDataSensitiveQoS() { usb.QOSCTRL.bit.DQOS = 2; }
+	inline void setConfigSensitiveQoS() { usb.QOSCTRL.bit.CQOS = 2; }
+
 	// USB speed
 	inline void setFullSpeed()       { usb.CTRLB.bit.SPDCONF = USB_DEVICE_CTRLB_SPDCONF_FS_Val;   }
 	inline void setLowSpeed()        { usb.CTRLB.bit.SPDCONF = USB_DEVICE_CTRLB_SPDCONF_LS_Val;   }

--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -295,6 +295,8 @@ void USBDeviceClass::init()
 	usbd.reset();
 
 	usbd.calibrate();
+	usbd.setDataSensitiveQoS();
+	usbd.setConfigSensitiveQoS();
 	usbd.setUSBDeviceMode();
 	usbd.runInStandby();
 	usbd.setFullSpeed();


### PR DESCRIPTION
By default this is `00` for both DQOS and CQOS, which means that USB is treated as a background operation and there is at least a one clock-cycle SRAM access latency. This reduces the SRAM clock-cycle latency for USB by setting it to `10`, giving it higher memory access priority.

This is done by [Adafruit](https://github.com/adafruit/uf2-samdx1/blob/master/src/startup_samd21.c#L254) and by the [Rust SAMD21 support crate](https://github.com/atsamd-rs/atsamd/blob/master/hal/src/samd21/usb/bus.rs#L690) (albeit at critical sensitivity) to improve USB performance and ensure correct behavior.
[Relevant datasheet section for QOSCTRL](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_DataSheet_DS40001882F.pdf#_OPENTOPIC_TOC_PROCESSING_d138e244709)
[Relevant datasheet explanation for QoS](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_DataSheet_DS40001882F.pdf#_OPENTOPIC_TOC_PROCESSING_d138e244709)