### PR TITLE
Fix crash when calling tone() with frequency 0

### DIFF
--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -57,6 +57,13 @@ void toneAccurateClock (uint32_t accurateSystemCoreClockFrequency)
 
 void tone (uint32_t outputPin, uint32_t frequency, uint32_t duration)
 {
+  
+  if (frequency == 0)
+  {
+    noTone(outputPin);
+    return;
+  }
+  
   // Configure interrupt request
   NVIC_DisableIRQ(TONE_TC_IRQn);
   NVIC_ClearPendingIRQ(TONE_TC_IRQn);

--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -58,6 +58,7 @@ void toneAccurateClock (uint32_t accurateSystemCoreClockFrequency)
 void tone (uint32_t outputPin, uint32_t frequency, uint32_t duration)
 {
   
+  // Avoid divide by zero error by calling 'noTone' instead
   if (frequency == 0)
   {
     noTone(outputPin);


### PR DESCRIPTION
Avoid division by 0 when a frequency of 0 is passed to tone(). If a 0 is passed, noTone() is called instead. Fixes arduino/ArduinoCore-samd#519