### PR TITLE
Fix infinite recursion issue in SERCOM::startTransmissionWIRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This repository contains the source code and configuration files of the Arduino Core
 for Atmel's SAMD21 processor (used on the Arduino/Genuino Zero, MKR1000 and MKRZero boards).
 
+## My mods contained in 'wire_timeout' branch
+
+This version of the core has the following changes:
+
+1. A modified version of jrowberg's excellent i2c wire timeout implementation. See pull request [#439](https://github.com/arduino/ArduinoCore-samd/pull/439). By the way I've made the default timeout 25ms. An example modification of Adafruits SSD1306 library for a 128x64 OLED is [here](https://github.com/acicuc/Adafruit_SSD1306/tree/wire_timeout). Albeit old, it still demonstrates one use for the i2c timeout implementation.
+2. A fix for the infamous infinite recursion SERCOM issue, see pull request [#535](https://github.com/arduino/ArduinoCore-samd/pull/535).
+3. The Serial.flush() blocks forever fix, see issue [#597](https://github.com/arduino/ArduinoCore-samd/issues/597).
+
+These are currently the main issues I've struck while working with the SAMD21 in the 'real' world. In particular 1&2 above have allowed for hot-swap and plug&play for devices on the i2c bus, and allows for complete device failure without locking up your entire system or blowing the stack! I'll add others as they raise their ugly heads within my projects.
+
 ## Installation on Arduino IDE
 
 This core is available as a package in the Arduino IDE cores manager.

--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -113,12 +113,10 @@ void SERCOM::enableUART()
 
 void SERCOM::flushUART()
 {
-  // Skip checking transmission completion if data register is empty
-  if(isDataRegisterEmptyUART())
-    return;
+  // Wait for transmission to complete, if ok to do so.
+  while(!sercom->USART.INTFLAG.bit.TXC && onFlushWaitUartTXC);
 
-  // Wait for transmission to complete
-  while(!sercom->USART.INTFLAG.bit.TXC);
+  onFlushWaitUartTXC = false;
 }
 
 void SERCOM::clearStatusUART()
@@ -185,6 +183,10 @@ int SERCOM::writeDataUART(uint8_t data)
 
   //Put data into DATA register
   sercom->USART.DATA.reg = (uint16_t)data;
+
+  // indicate it's ok to wait for TXC flag when flushing
+  onFlushWaitUartTXC = true;
+
   return 1;
 }
 

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -233,10 +233,10 @@ class SERCOM
 		uint32_t timeoutRef, restartTX_cnt, restartTX_limit = 10;
 		bool timeoutOccurred;
 
-    // Flag set when data is loaded into sercom->USART.DATA.reg.
-    // Helps with preventing UART lockups when flushing on startup
-    // and the asyncronous nature of the DRE and TXC interrupt flags.
-    bool onFlushWaitUartTXC = false;
+		// Flag set when data is loaded into sercom->USART.DATA.reg.
+		// Helps with preventing UART lockups when flushing on startup
+		// and the asyncronous nature of the DRE and TXC interrupt flags.
+		bool onFlushWaitUartTXC = false;
 };
 
 #endif

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -25,7 +25,7 @@
 #define SERCOM_NVIC_PRIORITY ((1<<__NVIC_PRIO_BITS) - 1)
 
 // timeout detection default length (zero is disabled)
-#define SERCOM_DEFAULT_I2C_OPERATION_TIMEOUT_MS 1000
+#define SERCOM_DEFAULT_I2C_OPERATION_TIMEOUT_MS 25
 
 typedef enum
 {

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -230,7 +230,7 @@ class SERCOM
 		void initTimeout( void );
 		bool testTimeout( void );
 		uint16_t timeoutInterval;
-		uint32_t timeoutRef, restartTX_cnt, restartTX_limit = 10;
+		uint32_t timeoutRef;
 		bool timeoutOccurred;
 
 		// Flag set when data is loaded into sercom->USART.DATA.reg.

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -24,6 +24,9 @@
 #define SERCOM_FREQ_REF      48000000
 #define SERCOM_NVIC_PRIORITY ((1<<__NVIC_PRIO_BITS) - 1)
 
+// timeout detection default length (zero is disabled)
+#define SERCOM_DEFAULT_I2C_OPERATION_TIMEOUT_MS 1000
+
 typedef enum
 {
 	UART_EXT_CLOCK = 0,
@@ -191,10 +194,10 @@ class SERCOM
 
 		void resetWIRE( void ) ;
 		void enableWIRE( void ) ;
-    void disableWIRE( void );
-    void prepareNackBitWIRE( void ) ;
-    void prepareAckBitWIRE( void ) ;
-    void prepareCommandBitsWire(uint8_t cmd);
+		void disableWIRE( void );
+		void prepareNackBitWIRE( void ) ;
+		void prepareAckBitWIRE( void ) ;
+		void prepareCommandBitsWire(uint8_t cmd);
 		bool startTransmissionWIRE(uint8_t address, SercomWireReadWriteFlag flag) ;
 		bool sendDataMasterWIRE(uint8_t data) ;
 		bool sendDataSlaveWIRE(uint8_t data) ;
@@ -209,15 +212,26 @@ class SERCOM
 		bool isRestartDetectedWIRE( void ) ;
 		bool isAddressMatch( void ) ;
 		bool isMasterReadOperationWIRE( void ) ;
-    bool isRXNackReceivedWIRE( void ) ;
+		bool isRXNackReceivedWIRE( void ) ;
 		int availableWIRE( void ) ;
 		uint8_t readDataWIRE( void ) ;
+		void setTimeout( uint16_t ms );
+		bool didTimeout( void );
 
 	private:
 		Sercom* sercom;
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate) ;
 		uint32_t division(uint32_t dividend, uint32_t divisor) ;
 		void initClockNVIC( void ) ;
+
+		void waitSyncWIRE( void ) ;
+
+		// timeout detection and tx restart for I2C operations
+		void initTimeout( void );
+		bool testTimeout( void );
+		uint16_t timeoutInterval;
+		uint32_t timeoutRef, restartTX_cnt, restartTX_limit = 5;
+		bool timeoutOccurred;
 };
 
 #endif

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -230,8 +230,13 @@ class SERCOM
 		void initTimeout( void );
 		bool testTimeout( void );
 		uint16_t timeoutInterval;
-		uint32_t timeoutRef, restartTX_cnt, restartTX_limit = 5;
+		uint32_t timeoutRef, restartTX_cnt, restartTX_limit = 10;
 		bool timeoutOccurred;
+
+    // Flag set when data is loaded into sercom->USART.DATA.reg.
+    // Helps with preventing UART lockups when flushing on startup
+    // and the asyncronous nature of the DRE and TXC interrupt flags.
+    bool onFlushWaitUartTXC = false;
 };
 
 #endif

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -35,6 +35,9 @@ TwoWire::TwoWire(SERCOM * s, uint8_t pinSDA, uint8_t pinSCL)
 }
 
 void TwoWire::begin(void) {
+  // track baud clock for auto-restarting bus in timeout condition
+  activeBaudrate = TWI_CLOCK;
+
   //Master Mode
   sercom->initMasterWIRE(TWI_CLOCK);
   sercom->enableWIRE();
@@ -53,6 +56,9 @@ void TwoWire::begin(uint8_t address, bool enableGeneralCall) {
 }
 
 void TwoWire::setClock(uint32_t baudrate) {
+  // track baud clock for auto-restarting bus in timeout condition
+  activeBaudrate = baudrate;
+
   sercom->disableWIRE();
   sercom->initMasterWIRE(baudrate);
   sercom->enableWIRE();
@@ -70,6 +76,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
   }
 
   size_t byteRead = 0;
+  bool busOwner;
 
   rxBuffer.clear();
 
@@ -78,26 +85,38 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
     // Read first data
     rxBuffer.store_char(sercom->readDataWIRE());
 
-    bool busOwner;
     // Connected to slave
-    for (byteRead = 1; byteRead < quantity && (busOwner = sercom->isBusOwnerWIRE()); ++byteRead)
+    for (byteRead = 1; byteRead < quantity && !sercom->didTimeout() && (busOwner = sercom->isBusOwnerWIRE()); ++byteRead)
     {
-      sercom->prepareAckBitWIRE();                          // Prepare Acknowledge
-      sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_READ); // Prepare the ACK command for the slave
-      rxBuffer.store_char(sercom->readDataWIRE());          // Read data and send the ACK
-    }
-    sercom->prepareNackBitWIRE();                           // Prepare NACK to stop slave transmission
-    //sercom->readDataWIRE();                               // Clear data register to send NACK
+      // prepare and send ACK for the slave
+      sercom->prepareAckBitWIRE();
+      sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_READ);
 
-    if (stopBit && busOwner)
-    {
-      sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);   // Send Stop unless arbitration was lost
+      if (quantity > 1) rxBuffer.store_char(sercom->readDataWIRE());    // Read next byte
     }
 
-    if (!busOwner)
+    sercom->prepareNackBitWIRE(); // prepare NACK for slave
+
+    if (!busOwner || sercom->didTimeout())
     {
       byteRead--;   // because last read byte was garbage/invalid
     }
+
+  }
+
+  // Send Stop if we still have control of the bus, or hit a timeout
+  if ((stopBit && busOwner) || sercom->didTimeout())
+  {
+    sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
+  }
+
+  // catch and handle timeout condition
+  if (sercom->didTimeout())
+  {
+    // reset the bus
+    setClock(activeBaudrate);
+    transmissionBegun = false;
+    return 0;
   }
 
   return byteRead;
@@ -121,35 +140,50 @@ void TwoWire::beginTransmission(uint8_t address) {
 //  1 : Data too long
 //  2 : NACK on transmit of address
 //  3 : NACK on transmit of data
-//  4 : Other error
+//  4 : Timeout
+//  5 : Other error
 uint8_t TwoWire::endTransmission(bool stopBit)
 {
+  uint8_t errCode = 0;
+  bool busOwner;
+
   transmissionBegun = false ;
 
   // Start I2C transmission
   if ( !sercom->startTransmissionWIRE( txAddress, WIRE_WRITE_FLAG ) )
   {
-    sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-    return 2 ;  // Address error
+    errCode = 2; // Address error
   }
 
   // Send all buffer
-  while( txBuffer.available() )
-  {
-    // Trying to send data
-    if ( !sercom->sendDataMasterWIRE( txBuffer.read_char() ) )
+  if (!errCode) {
+    while ( txBuffer.available() && (busOwner = sercom->isBusOwnerWIRE()) )
     {
-      sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-      return 3 ;  // Nack or error
+        // Trying to send data
+        if ( !sercom->sendDataMasterWIRE( txBuffer.read_char() ) )
+        {
+          errCode = 3; // Nack or error
+          txBuffer.clear();
+          break;
+        }
     }
   }
-  
-  if (stopBit)
+
+  // Send Stop if we still have control of the bus, or hit an error
+  if ((stopBit && busOwner) || errCode)
   {
     sercom->prepareCommandBitsWire(WIRE_MASTER_ACT_STOP);
-  }   
+  }
 
-  return 0;
+  // catch timeout condition
+  if (sercom->didTimeout()) {
+    // reset the bus
+    setClock(activeBaudrate);
+    transmissionBegun = false;
+    errCode = 4;
+  }
+
+  return errCode;
 }
 
 uint8_t TwoWire::endTransmission()
@@ -219,7 +253,7 @@ void TwoWire::onService(void)
 {
   if ( sercom->isSlaveWIRE() )
   {
-    if(sercom->isStopDetectedWIRE() || 
+    if(sercom->isStopDetectedWIRE() ||
         (sercom->isAddressMatch() && sercom->isRestartDetectedWIRE() && !sercom->isMasterReadOperationWIRE())) //Stop or Restart detected
     {
       sercom->prepareAckBitWIRE();
@@ -230,7 +264,7 @@ void TwoWire::onService(void)
       {
         onReceiveCallback(available());
       }
-      
+
       rxBuffer.clear();
     }
     else if(sercom->isAddressMatch())  //Address Match
@@ -264,12 +298,12 @@ void TwoWire::onService(void)
         transmissionBegun = sercom->sendDataSlaveWIRE(c);
       } else { //Received data
         if (rxBuffer.isFull()) {
-          sercom->prepareNackBitWIRE(); 
+          sercom->prepareNackBitWIRE();
         } else {
           //Store data
           rxBuffer.store_char(sercom->readDataWIRE());
 
-          sercom->prepareAckBitWIRE(); 
+          sercom->prepareAckBitWIRE();
         }
 
         sercom->prepareCommandBitsWire(0x03);
@@ -334,4 +368,3 @@ void TwoWire::onService(void)
     Wire5.onService();
   }
 #endif
-

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -29,6 +29,9 @@
  // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
+ // WIRE_HAS_TIMEOUT means Wire implements timeout detection
+#define WIRE_HAS_TIMEOUT 1
+
 class TwoWire : public Stream
 {
   public:
@@ -44,6 +47,9 @@ class TwoWire : public Stream
 
     uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
     uint8_t requestFrom(uint8_t address, size_t quantity);
+    
+    bool didTimeout() { return sercom->didTimeout(); }
+    bool setTimeout(uint16_t ms) { sercom->setTimeout(ms); }
 
     size_t write(uint8_t data);
     size_t write(const uint8_t * data, size_t quantity);
@@ -69,6 +75,9 @@ class TwoWire : public Stream
     uint8_t _uc_pinSCL;
 
     bool transmissionBegun;
+
+    // Used to re-initialize the clock rate after a timeout
+    uint32_t activeBaudrate;
 
     // RX Buffer
     RingBufferN<256> rxBuffer;

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -47,9 +47,9 @@ class TwoWire : public Stream
 
     uint8_t requestFrom(uint8_t address, size_t quantity, bool stopBit);
     uint8_t requestFrom(uint8_t address, size_t quantity);
-    
+
     bool didTimeout() { return sercom->didTimeout(); }
-    bool setTimeout(uint16_t ms) { sercom->setTimeout(ms); }
+    void setTimeout(uint16_t ms) { sercom->setTimeout(ms); }
 
     size_t write(uint8_t data);
     size_t write(const uint8_t * data, size_t quantity);


### PR DESCRIPTION
* If a significant hardware issue is struck startTransmissionWIRE
  calls itself to restart sending the address+r/w byte. The stack
  can be blown very quickly in the event of a prolonged hardware
  issue that warrants transmission restarts. A restart limit has
  been added (currently set at 5) to fix this issue.

* This fixes issue #476 and it builds on work by @jrowberg in which
  a timeout was added addressing issue #439.

* Some code simplification and tidying has followed from #439 and #476
  being resolved.