### PR TITLE
Remove -Wno-expansion-to-defined  

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -31,7 +31,7 @@ extern "C"{
 #endif // __cplusplus
 
 // Include Atmel headers
-#include "sam.h"
+#include <samd.h>
 
 #define clockCyclesPerMicrosecond() ( SystemCoreClock / 1000000L )
 #define clockCyclesToMicroseconds(a) ( ((a) * 1000L) / (SystemCoreClock / 1000L) )

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -19,7 +19,7 @@
 #ifndef _SERCOM_CLASS_
 #define _SERCOM_CLASS_
 
-#include "sam.h"
+#include <samd.h>
 
 #define SERCOM_FREQ_REF      48000000
 #define SERCOM_NVIC_PRIORITY ((1<<__NVIC_PRIO_BITS) - 1)

--- a/cores/arduino/WVariant.h
+++ b/cores/arduino/WVariant.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <stdint.h>
-#include "sam.h"
+#include <samd.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/cores/arduino/cortex_handlers.c
+++ b/cores/arduino/cortex_handlers.c
@@ -16,7 +16,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <sam.h>
+#include <samd.h>
 #include <variant.h>
 #include <stdio.h>
 

--- a/cores/arduino/startup.c
+++ b/cores/arduino/startup.c
@@ -16,7 +16,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "sam.h"
+#include <samd.h>
 #include "variant.h"
 
 #include <stdio.h>

--- a/cores/arduino/wiring_private.h
+++ b/cores/arduino/wiring_private.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 // Includes Atmel CMSIS
-#include "sam.h"
+#include <samd.h>
 
 int pinPeripheral( uint32_t ulPin, EPioType ulPeripheral );
 

--- a/platform.txt
+++ b/platform.txt
@@ -28,8 +28,8 @@ version=1.8.9
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w
 compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall -Wno-expansion-to-defined
-compiler.warning_flags.all=-Wall -Wextra -Wno-expansion-to-defined
+compiler.warning_flags.more=-Wall
+compiler.warning_flags.all=-Wall -Wextra
 
 # EXPERIMENTAL feature: optimization flags
 #  - this is alpha and may be subject to change without notice


### PR DESCRIPTION
By including a different CMSIS header, this warning no longer needs to be supressed.

This fixes #556.