### PR TITLE
Fixing inaccessible individual header version member

### DIFF
--- a/libraries/SNU/extras/NiNaBoot/NiNaBoot.ino
+++ b/libraries/SNU/extras/NiNaBoot/NiNaBoot.ino
@@ -156,7 +156,7 @@ int main() {
 
     union HeaderVersion
     {
-      typedef struct __attribute__((packed))
+      struct __attribute__((packed))
       {
         uint32_t header_version    :  6;
         uint32_t compression       :  1;


### PR DESCRIPTION
This change does not change the SNU binaries upon recompilation. It just future-proofs the code where those fields might be accessed.