### PR TITLE
Add CI workflows (to be used with ArduinoCore-API integration)

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -67,6 +67,22 @@ jobs:
           - board:
               type: "tian"
             additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata"'
+          # MKRGSM1400 board
+          - board:
+              fqbn: "arduino:samd:mkrgsm1400"
+            additional-sketch-paths: "~/Arduino/libraries/MKRGSM/examples"
+          # MKRNB1500 board
+          - board:
+              fqbn: "arduino:samd:mkrnb1500"
+            additional-sketch-paths: "~/Arduino/libraries/MKRNB/examples"
+          # MKRWAN board
+          - board:
+              fqbn: '"arduino:samd:mkrwan1300" "arduino:samd:mkrwan1310"'
+            additional-sketch-paths: "~/Arduino/libraries/MKRWAN/examples"
+          # WiFi101
+          - board:
+              type: "usb"
+            additional-sketch-paths: "~/Arduino/libraries/WiFi101/examples"
           
     steps:
       - name: Checkout repository
@@ -135,6 +151,10 @@ jobs:
             - name: Temboo
             - name: ArduinoIoTCloud
             - name: Madgwick
+            - name: MKRGSM
+            - name: MKRNB
+            - name: MKRWAN
+            - name: WiFi101
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:samd"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,146 @@
+name: Compile Examples
+
+on: [pull_request, push]
+
+jobs:
+  compile-test:
+    runs-on: ubuntu-latest
+
+    env:
+      # libraries to install for all boards
+      UNIVERSAL_LIBRARIES: '"MFRC522" "Keyboard" "Mouse" "Servo" "LiquidCrystal" "CapacitiveSensor"'
+      # sketch paths to compile (recursive) for all boards
+      UNIVERSAL_SKETCH_PATHS: '"extras/shared/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data"' 
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board: [
+          {"fqbn": "arduino:samd:arduino_zero_edbg", "type": "usb"},  #normal
+          {"fqbn": "arduino:samd:arduino_zero_native", "type": "usb"},
+          {"fqbn": "arduino:samd:mkr1000", "type": "usb"},
+          {"fqbn": "arduino:samd:mkrzero", "type": "usb"},
+          {"fqbn": "arduino:samd:mkrwifi1010", "type": "mkrwifi_nb1500"},
+          {"fqbn": "arduino:samd:nano_33_iot", "type": "nano_mkrwan1310"},
+          {"fqbn": "arduino:samd:mkrfox1200", "type": "usb"},
+          {"fqbn": "arduino:samd:mkrwan1300", "type": "usb"},
+          {"fqbn": "arduino:samd:mkrwan1310", "type": "nano_mkrwan1310"},
+          {"fqbn": "arduino:samd:mkrgsm1400", "type": "usb"},
+          {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrwifi_nb1500"},
+          {"fqbn": "arduino:samd:mkrvidor4000", "type": "vidor"},
+          {"fqbn": "arduino:samd:adafruit_circuitplayground_m0", "type": "adafruit_playg"},
+          {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero"},  #normal
+          {"fqbn": "arduino:samd:mzero_pro_bl", "type": "mzero"},
+          {"fqbn": "arduino:samd:mzero_bl", "type": "mzero"},
+          {"fqbn": "arduino:samd:tian", "type": "tian"} #,
+          #{"fqbn": "arduino:samd:tian_cons", "type": "usb"}  #normal
+        ]
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          # Normal USB boards with all the general libraries
+          - board:
+              type: "usb"
+            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata" "libraries/I2S/examples" "libraries/SDU/examples"'
+          # Vidor board
+          - board:
+              type: "vidor"
+            additional-sketch-paths: '"libraries/SAMD_BootloaderUpdater/examples" "libraries/I2S/examples"'
+          # mkrwifi1010 and mkrnb1500 boards
+          - board:
+              type: "mkrwifi_nb1500"
+            additional-sketch-paths: '"libraries/I2S/examples" "libraries/SDU/examples"'
+          # nano_33_iot and mkrwan1310 boards
+          - board:
+              type: "nano_mkrwan1310"
+            additional-sketch-paths: "libraries/I2S/examples"
+          # adafruit_cicrcuitplayground board
+          - board:
+              type: "adafruit_playg"
+            additional-sketch-paths: "libraries/SDU/examples"
+          # mzero boards
+          - board:
+              type: "mzero"
+            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata" "libraries/SDU/examples"'
+          # tian board
+          - board:
+              type: "tian"
+            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata"'
+          
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          path: extras/ArduinoCore-API
+
+      - name: Install ArduinoCore-API
+        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
+
+      - name: Checkout Adafruit WiFiNINA
+        uses: actions/checkout@v2
+        with:
+          repository: adafruit/WiFiNINA
+          path: adafruit/WiFiNINA
+
+      - name: Compile examples
+        uses: per1234/actions/libraries/compile-examples@master
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          libraries: |
+            - name: MFRC522
+            - name: Arduino_MKRMEM
+            - name: FlashStorage
+            - source-url: https://github.com/arduino-libraries/Keyboard.git
+            - name: Mouse
+            - name: Servo
+            - name: LiquidCrystal
+            - name: CapacitiveSensor
+            - name: Ethernet
+            - name: ArduinoBearSSL
+            - name: Arduino_APDS9960
+            - name: Servo
+            - name: Arduino_LSM9DS1
+            - name: ArduinoHttpClient
+            - name: NTPClient
+            - name: TFT
+            - name: ArduinoMqttClient
+            - name: Arduino_CRC32
+            - name: Arduino_LSM6DS3
+            - name: Stepper
+            - name: SD
+            - name: WiFi101
+            - name: Arduino_JSON
+            - name: Arduino_HTS221
+            - name: Firmata
+            - name: ArduinoMotorCarrier
+            - name: ArduinoCloudThing
+            - name: Arduino_DebugUtils
+            - name: WiFi Link
+            - name: Arduino_LPS22HB
+            - name: CTC GO MOTIONS
+            - name: ArduinoModbus
+            - name: ArduinoIoTCloudBearSSL
+            - name: ArduinoDMX
+            - name: ArduinoRS485
+            - name: Arduino_OAuth
+            - name: CTC GO CORE
+            - name: WiFi
+            - name: Bridge
+            - name: Temboo
+            - name: ArduinoIoTCloud
+            - name: Madgwick
+          platforms: |
+            # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
+            - name: "arduino:samd"
+            # Overwrite the Board Manager installation with the local platform
+            - source-path: "./"
+              name: "arduino:samd"
+          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          enable-size-deltas-report: 'true'
+          verbose: 'true'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -243,7 +243,7 @@ jobs:
             - name: WiFiNINA
             - source-url: https://github.com/vidor-libraries/VidorPeripherals.git
           platforms: |
-            # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
+            # Use Board Manager to install the latest release of Arduino SAMD Boards to get the toolchain
             - name: "arduino:samd"
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -146,7 +146,11 @@ jobs:
             - name: WiFi
             - name: Bridge
             - name: Temboo
-            - name: ArduinoIoTCloud
+            - name: Arduino_ConnectionHandler
+            - name: ArduinoECCX08
+            - name: RTCZero
+            - source-url: https://github.com/arduino-libraries/ArduinoIoTCloud.git
+              version: latest
             - name: Madgwick
             - name: MKRGSM
             - name: MKRNB

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -31,7 +31,6 @@ jobs:
         - libraries/SPI
         - libraries/SFU/examples/SFU_LoadBinary
         - libraries/SAMD_AnalogCorrection
-        - ~/Arduino/libraries/Keyboard/examples/Serial
         - ~/Arduino/libraries/Servo/examples
         - ~/Arduino/libraries/LiquidCrystal/examples
         - ~/Arduino/libraries/Ethernet/examples
@@ -200,7 +199,7 @@ jobs:
             - name: MFRC522
             - name: Arduino_MKRMEM
             - name: FlashStorage
-            - source-url: https://github.com/arduino-libraries/Keyboard.git
+            - name: Keyboard
             - name: Mouse
             - name: Servo
             - name: LiquidCrystal

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,6 +1,22 @@
 name: Compile Examples
 
-on: [pull_request, push]
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
 
 jobs:
   compile-test:
@@ -118,7 +134,6 @@ jobs:
             - name: Ethernet
             - name: ArduinoBearSSL
             - name: Arduino_APDS9960
-            - name: Servo
             - name: Arduino_LSM9DS1
             - name: ArduinoHttpClient
             - name: NTPClient

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -60,23 +60,23 @@ jobs:
 
       matrix:
         board: [
-          {"fqbn": "arduino:samd:arduino_zero_edbg", "type": "usb"},
-          {"fqbn": "arduino:samd:arduino_zero_native", "type": "usb"},
-          {"fqbn": "arduino:samd:mkr1000", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrzero", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrwifi1010", "type": "mkrWiFi1010"},
-          {"fqbn": "arduino:samd:nano_33_iot", "type": "nano33IoT"},
-          {"fqbn": "arduino:samd:mkrfox1200", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrwan1300", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrwan1310", "type": "mkrwan1310"},
-          {"fqbn": "arduino:samd:mkrgsm1400", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrNB1500"},
-          {"fqbn": "arduino:samd:mkrvidor4000", "type": "vidor"},
-          {"fqbn": "arduino:samd:adafruit_circuitplayground_m0", "type": "adafruit_playg"},
-          {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero"},
-          {"fqbn": "arduino:samd:mzero_pro_bl", "type": "mzero"},
-          {"fqbn": "arduino:samd:mzero_bl", "type": "mzero"},
-          {"fqbn": "arduino:samd:tian", "type": "tian"}
+          {"fqbn": "arduino:samd:arduino_zero_edbg", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:arduino_zero_native", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkr1000", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrzero", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrwifi1010", "type": "mkrWiFi1010", "WAN": "false"},
+          {"fqbn": "arduino:samd:nano_33_iot", "type": "nano33IoT", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrfox1200", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrwan1300", "type": "usb", "WAN": "true"},
+          {"fqbn": "arduino:samd:mkrwan1310", "type": "mkrwan1310", "WAN": "true"},
+          {"fqbn": "arduino:samd:mkrgsm1400", "type": "usb", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrNB1500", "WAN": "false"},
+          {"fqbn": "arduino:samd:mkrvidor4000", "type": "vidor", "WAN": "false"},
+          {"fqbn": "arduino:samd:adafruit_circuitplayground_m0", "type": "adafruit_playg", "WAN": "false"},
+          {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero", "WAN": "false"},
+          {"fqbn": "arduino:samd:mzero_pro_bl", "type": "mzero", "WAN": "false"},
+          {"fqbn": "arduino:samd:mzero_bl", "type": "mzero", "WAN": "false"},
+          {"fqbn": "arduino:samd:tian", "type": "tian", "WAN": "false"}
         ]
 
         # make board type-specific customizations to the matrix jobs
@@ -171,8 +171,8 @@ jobs:
               - ~/Arduino/libraries/MKRNB/examples
           # MKRWAN board
           - board:
-              fqbn: '"arduino:samd:mkrwan1300" "arduino:samd:mkrwan1310"'
-            additional-sketch-paths: |
+              WAN: "true"
+            wan-sketch-paths: |
               - ~/Arduino/libraries/MKRWAN/examples
 
     steps:
@@ -257,6 +257,7 @@ jobs:
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}
             ${{ matrix.mkrgsm1400-sketch-paths }}
+            ${{ matrix.wan-sketch-paths }}
           enable-deltas-report: 'true'
           verbose: 'true'
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -162,7 +162,7 @@ jobs:
           # MKRGSM1400 board
           - board:
               fqbn: "arduino:samd:mkrgsm1400"
-            additional-sketch-paths: |
+            mkrgsm1400-sketch-paths: |
               - ~/Arduino/libraries/MKRGSM/examples
           # MKRNB1500 board
           - board:

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # libraries to install for all boards
-      UNIVERSAL_LIBRARIES: '"MFRC522" "Keyboard" "Mouse" "Servo" "LiquidCrystal" "CapacitiveSensor"'
       # sketch paths to compile (recursive) for all boards
       UNIVERSAL_SKETCH_PATHS: |
         - extras/examples

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Checkout ArduinoCore-API
         uses: actions/checkout@v2
         with:
-          repository: giulcioffi/ArduinoCore-API
-          ref: namespaced_api_Hardware
+          repository: arduino/ArduinoCore-API
           path: extras/ArduinoCore-API
 
       - name: Install ArduinoCore-API

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -116,6 +116,7 @@ jobs:
             additional-sketch-paths: |
               - libraries/I2S/examples
               - libraries/SDU/examples
+              - ~/Arduino/libraries/MKRNB/examples
           # nano_33_iot
           - board:
               type: "nano33IoT"
@@ -164,11 +165,6 @@ jobs:
               fqbn: "arduino:samd:mkrgsm1400"
             mkrgsm1400-sketch-paths: |
               - ~/Arduino/libraries/MKRGSM/examples
-          # MKRNB1500 board
-          - board:
-              fqbn: "arduino:samd:mkrnb1500"
-            additional-sketch-paths: |
-              - ~/Arduino/libraries/MKRNB/examples
           # MKRWAN board
           - board:
               WAN: "true"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -102,6 +102,7 @@ jobs:
             additional-sketch-paths: |
               - libraries/SAMD_BootloaderUpdater/examples
               - libraries/I2S/examples
+              - ~/Arduino/libraries/VidorPeripherals/examples
           # mkrwifi1010
           - board:
               type: "mkrWiFi1010"
@@ -246,6 +247,7 @@ jobs:
             - name: LoRa
             - name: MKRWAN
             - name: WiFiNINA
+            - source-url: https://github.com/vidor-libraries/VidorPeripherals.git
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:samd"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,7 +54,6 @@ jobs:
         - ~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data
         - ~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data
         - ~/Arduino/libraries/WiFi101/examples
-        - ~/Arduino/libraries/WiFiNINA/examples
 
     strategy:
       fail-fast: false
@@ -65,13 +64,13 @@ jobs:
           {"fqbn": "arduino:samd:arduino_zero_native", "type": "usb"},
           {"fqbn": "arduino:samd:mkr1000", "type": "usb"},
           {"fqbn": "arduino:samd:mkrzero", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrwifi1010", "type": "mkrwifi_nb1500"},
-          {"fqbn": "arduino:samd:nano_33_iot", "type": "nano_mkrwan1310"},
+          {"fqbn": "arduino:samd:mkrwifi1010", "type": "mkrWiFi1010"},
+          {"fqbn": "arduino:samd:nano_33_iot", "type": "nano33IoT"},
           {"fqbn": "arduino:samd:mkrfox1200", "type": "usb"},
           {"fqbn": "arduino:samd:mkrwan1300", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrwan1310", "type": "nano_mkrwan1310"},
+          {"fqbn": "arduino:samd:mkrwan1310", "type": "mkrwan1310"},
           {"fqbn": "arduino:samd:mkrgsm1400", "type": "usb"},
-          {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrwifi_nb1500"},
+          {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrNB1500"},
           {"fqbn": "arduino:samd:mkrvidor4000", "type": "vidor"},
           {"fqbn": "arduino:samd:adafruit_circuitplayground_m0", "type": "adafruit_playg"},
           {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero"},  #normal
@@ -104,15 +103,28 @@ jobs:
             additional-sketch-paths: |
               - libraries/SAMD_BootloaderUpdater/examples
               - libraries/I2S/examples
-          # mkrwifi1010 and mkrnb1500 boards
+          # mkrwifi1010
           - board:
-              type: "mkrwifi_nb1500"
+              type: "mkrWiFi1010"
             additional-sketch-paths: |
               - libraries/I2S/examples
               - libraries/SDU/examples
-          # nano_33_iot and mkrwan1310 boards
+              - ~/Arduino/libraries/WiFiNINA/examples
+          # mkrnb1500 boards
           - board:
-              type: "nano_mkrwan1310"
+              type: "mkrNB1500"
+            additional-sketch-paths: |
+              - libraries/I2S/examples
+              - libraries/SDU/examples
+          # nano_33_iot
+          - board:
+              type: "nano33IoT"
+            additional-sketch-paths: |
+              - libraries/I2S/examples
+              - ~/Arduino/libraries/WiFiNINA/examples
+          # mkrwan1310
+          - board:
+              type: "mkrwan1310"
             additional-sketch-paths: |
               - libraries/I2S/examples
           # adafruit_cicrcuitplayground board

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -26,7 +26,36 @@ jobs:
       # libraries to install for all boards
       UNIVERSAL_LIBRARIES: '"MFRC522" "Keyboard" "Mouse" "Servo" "LiquidCrystal" "CapacitiveSensor"'
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data" "~/Arduino/libraries/WiFi101/examples"'
+      UNIVERSAL_SKETCH_PATHS: |
+        - extras/examples
+        - libraries/Wire
+        - libraries/USBHost
+        - libraries/SPI
+        - libraries/SFU/examples/SFU_LoadBinary
+        - libraries/SAMD_AnalogCorrection
+        - ~/Arduino/libraries/Keyboard/examples/Serial
+        - ~/Arduino/libraries/Servo/examples
+        - ~/Arduino/libraries/LiquidCrystal/examples
+        - ~/Arduino/libraries/Ethernet/examples
+        - ~/Arduino/libraries/SD/examples
+        - ~/Arduino/libraries/WiFi/examples
+        - ~/Arduino/libraries/Arduino_LSM9DS1/examples
+        - ~/Arduino/libraries/Arduino_JSON/examples
+        - ~/Arduino/libraries/MFRC522/examples/ChangeUID
+        - ~/Arduino/libraries/MFRC522/examples/DumpInfo
+        - ~/Arduino/libraries/MFRC522/examples/FixBrickedUID
+        - ~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock
+        - ~/Arduino/libraries/MFRC522/examples/MinimalInterrupt
+        - ~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH
+        - ~/Arduino/libraries/MFRC522/examples/RFID-Cloner
+        - ~/Arduino/libraries/MFRC522/examples/ReadAndWrite
+        - ~/Arduino/libraries/MFRC522/examples/ReadNUID
+        - ~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader
+        - ~/Arduino/libraries/MFRC522/examples/firmware_check
+        - ~/Arduino/libraries/MFRC522/examples/rfid_default_keys
+        - ~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data
+        - ~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data
+        - ~/Arduino/libraries/WiFi101/examples
 
     strategy:
       fail-fast: false
@@ -58,43 +87,82 @@ jobs:
           # Normal USB boards with all the general libraries
           - board:
               type: "usb"
-            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata" "libraries/I2S/examples" "libraries/SDU/examples"'
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataPlus
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/ServoFirmata
+              - ~/Arduino/libraries/Firmata/examples/EchoString
+              - ~/Arduino/libraries/Firmata/examples/AnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/AllInputsFirmata
+              - libraries/I2S/examples
+              - libraries/SDU/examples
           # Vidor board
           - board:
               type: "vidor"
-            additional-sketch-paths: '"libraries/SAMD_BootloaderUpdater/examples" "libraries/I2S/examples"'
+            additional-sketch-paths: |
+              - libraries/SAMD_BootloaderUpdater/examples
+              - libraries/I2S/examples
           # mkrwifi1010 and mkrnb1500 boards
           - board:
               type: "mkrwifi_nb1500"
-            additional-sketch-paths: '"libraries/I2S/examples" "libraries/SDU/examples"'
+            additional-sketch-paths: |
+              - libraries/I2S/examples
+              - libraries/SDU/examples
           # nano_33_iot and mkrwan1310 boards
           - board:
               type: "nano_mkrwan1310"
-            additional-sketch-paths: "libraries/I2S/examples"
+            additional-sketch-paths: |
+              - libraries/I2S/examples
           # adafruit_cicrcuitplayground board
           - board:
               type: "adafruit_playg"
-            additional-sketch-paths: "libraries/SDU/examples"
+            additional-sketch-paths: |
+              - libraries/SDU/examples
           # mzero boards
           - board:
               type: "mzero"
-            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata" "libraries/SDU/examples"'
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataPlus
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/ServoFirmata
+              - ~/Arduino/libraries/Firmata/examples/EchoString
+              - ~/Arduino/libraries/Firmata/examples/AnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/AllInputsFirmata
+              - libraries/SDU/examples
           # tian board
           - board:
               type: "tian"
-            additional-sketch-paths: '"~/Arduino/libraries/Firmata/examples/StandardFirmataPlus" "~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet" "~/Arduino/libraries/Firmata/examples/StandardFirmata" "~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata" "~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata" "~/Arduino/libraries/Firmata/examples/ServoFirmata" "~/Arduino/libraries/Firmata/examples/EchoString" "~/Arduino/libraries/Firmata/examples/AnalogFirmata" "~/Arduino/libraries/Firmata/examples/AllInputsFirmata"'
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataPlus
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmataEthernet
+              - ~/Arduino/libraries/Firmata/examples/StandardFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleDigitalFirmata
+              - ~/Arduino/libraries/Firmata/examples/SimpleAnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/ServoFirmata
+              - ~/Arduino/libraries/Firmata/examples/EchoString
+              - ~/Arduino/libraries/Firmata/examples/AnalogFirmata
+              - ~/Arduino/libraries/Firmata/examples/AllInputsFirmata
           # MKRGSM1400 board
           - board:
               fqbn: "arduino:samd:mkrgsm1400"
-            additional-sketch-paths: "~/Arduino/libraries/MKRGSM/examples"
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/MKRGSM/examples
           # MKRNB1500 board
           - board:
               fqbn: "arduino:samd:mkrnb1500"
-            additional-sketch-paths: "~/Arduino/libraries/MKRNB/examples"
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/MKRNB/examples
           # MKRWAN board
           - board:
               fqbn: '"arduino:samd:mkrwan1300" "arduino:samd:mkrwan1310"'
-            additional-sketch-paths: "~/Arduino/libraries/MKRWAN/examples"
+            additional-sketch-paths: |
+              - ~/Arduino/libraries/MKRWAN/examples
 
     steps:
       - name: Checkout repository
@@ -179,6 +247,8 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:samd"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.additional-sketch-paths }}
           enable-size-deltas-report: 'false'
           verbose: 'true'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -26,7 +26,7 @@ jobs:
       # libraries to install for all boards
       UNIVERSAL_LIBRARIES: '"MFRC522" "Keyboard" "Mouse" "Servo" "LiquidCrystal" "CapacitiveSensor"'
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"extras/shared/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data" "~/Arduino/libraries/WiFi101/examples"'
+      UNIVERSAL_SKETCH_PATHS: '"extras/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data" "~/Arduino/libraries/WiFi101/examples"'
 
     strategy:
       fail-fast: false
@@ -115,6 +115,12 @@ jobs:
         with:
           repository: adafruit/WiFiNINA
           path: adafruit/WiFiNINA
+
+      - name: Checkout Basic examples
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/arduino-examples
+          path: extras
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -195,7 +195,7 @@ jobs:
           path: extras
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Checkout ArduinoCore-API
         uses: actions/checkout@v2
         with:
-          repository: arduino/ArduinoCore-API
+          repository: giulcioffi/ArduinoCore-API
+          ref: namespaced_api_Hardware
           path: extras/ArduinoCore-API
 
       - name: Install ArduinoCore-API

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -90,7 +90,7 @@ jobs:
           path: adafruit/WiFiNINA
 
       - name: Compile examples
-        uses: per1234/actions/libraries/compile-examples@master
+        uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |
@@ -143,5 +143,5 @@ jobs:
             - source-path: "./"
               name: "arduino:samd"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
-          enable-size-deltas-report: 'true'
+          enable-size-deltas-report: 'false'
           verbose: 'true'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -255,5 +255,11 @@ jobs:
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}
-          enable-deltas-report: 'false'
+          enable-deltas-report: 'true'
           verbose: 'true'
+
+      - name: Save memory usage change report as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: size-deltas-reports
+          path: size-deltas-reports

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -60,7 +60,7 @@ jobs:
 
       matrix:
         board: [
-          {"fqbn": "arduino:samd:arduino_zero_edbg", "type": "usb"},  #normal
+          {"fqbn": "arduino:samd:arduino_zero_edbg", "type": "usb"},
           {"fqbn": "arduino:samd:arduino_zero_native", "type": "usb"},
           {"fqbn": "arduino:samd:mkr1000", "type": "usb"},
           {"fqbn": "arduino:samd:mkrzero", "type": "usb"},
@@ -73,11 +73,10 @@ jobs:
           {"fqbn": "arduino:samd:mkrnb1500", "type": "mkrNB1500"},
           {"fqbn": "arduino:samd:mkrvidor4000", "type": "vidor"},
           {"fqbn": "arduino:samd:adafruit_circuitplayground_m0", "type": "adafruit_playg"},
-          {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero"},  #normal
+          {"fqbn": "arduino:samd:mzero_pro_bl_dbg", "type": "mzero"},
           {"fqbn": "arduino:samd:mzero_pro_bl", "type": "mzero"},
           {"fqbn": "arduino:samd:mzero_bl", "type": "mzero"},
-          {"fqbn": "arduino:samd:tian", "type": "tian"} #,
-          #{"fqbn": "arduino:samd:tian_cons", "type": "usb"}  #normal
+          {"fqbn": "arduino:samd:tian", "type": "tian"}
         ]
 
         # make board type-specific customizations to the matrix jobs

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -146,12 +146,7 @@ jobs:
             - name: WiFi
             - name: Bridge
             - name: Temboo
-            - source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler.git
-              version: latest
-            - name: ArduinoECCX08
-            - name: RTCZero
-            - source-url: https://github.com/arduino-libraries/ArduinoIoTCloud.git
-              version: latest
+            - name: ArduinoIoTCloud
             - name: Madgwick
             - name: MKRGSM
             - name: MKRNB

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -200,8 +200,7 @@ jobs:
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |
-            - source-url: https://github.com/giulcioffi/WiFi101.git
-              version: namespaced_api
+            - source-url: https://github.com/arduino-libraries/WiFi101.git
             - name: MFRC522
             - name: Arduino_MKRMEM
             - name: FlashStorage

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -155,6 +155,7 @@ jobs:
             - name: Madgwick
             - name: MKRGSM
             - name: MKRNB
+            - name: LoRa
             - name: MKRWAN
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -146,7 +146,8 @@ jobs:
             - name: WiFi
             - name: Bridge
             - name: Temboo
-            - name: Arduino_ConnectionHandler
+            - source-url: https://github.com/arduino-libraries/Arduino_ConnectionHandler.git
+              version: latest
             - name: ArduinoECCX08
             - name: RTCZero
             - source-url: https://github.com/arduino-libraries/ArduinoIoTCloud.git

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -256,11 +256,12 @@ jobs:
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}
+            ${{ matrix.mkrgsm1400-sketch-paths }}
           enable-deltas-report: 'true'
           verbose: 'true'
 
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v1
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          name: sketches-reports
+          path: sketches-reports

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,6 +54,7 @@ jobs:
         - ~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data
         - ~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data
         - ~/Arduino/libraries/WiFi101/examples
+        - ~/Arduino/libraries/WiFiNINA/examples
 
     strategy:
       fail-fast: false
@@ -176,12 +177,6 @@ jobs:
       - name: Install ArduinoCore-API
         run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
 
-      - name: Checkout Adafruit WiFiNINA
-        uses: actions/checkout@v2
-        with:
-          repository: adafruit/WiFiNINA
-          path: adafruit/WiFiNINA
-
       - name: Checkout Basic examples
         uses: actions/checkout@v2
         with:
@@ -239,6 +234,7 @@ jobs:
             - name: MKRNB
             - name: LoRa
             - name: MKRWAN
+            - name: WiFiNINA
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:samd"
@@ -248,5 +244,5 @@ jobs:
           sketch-paths: |
             ${{ env.UNIVERSAL_SKETCH_PATHS }}
             ${{ matrix.additional-sketch-paths }}
-          enable-size-deltas-report: 'false'
+          enable-deltas-report: 'false'
           verbose: 'true'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -10,7 +10,7 @@ jobs:
       # libraries to install for all boards
       UNIVERSAL_LIBRARIES: '"MFRC522" "Keyboard" "Mouse" "Servo" "LiquidCrystal" "CapacitiveSensor"'
       # sketch paths to compile (recursive) for all boards
-      UNIVERSAL_SKETCH_PATHS: '"extras/shared/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data"' 
+      UNIVERSAL_SKETCH_PATHS: '"extras/shared/examples" "libraries/Wire" "libraries/USBHost" "libraries/SPI" "libraries/SFU/examples/SFU_LoadBinary" "libraries/SAMD_AnalogCorrection" "~/Arduino/libraries/Keyboard/examples/Serial" "~/Arduino/libraries/Servo/examples" "~/Arduino/libraries/LiquidCrystal/examples" "~/Arduino/libraries/Ethernet/examples" "~/Arduino/libraries/SD/examples" "~/Arduino/libraries/WiFi/examples" "~/Arduino/libraries/Arduino_LSM9DS1/examples" "~/Arduino/libraries/Arduino_JSON/examples" "~/Arduino/libraries/MFRC522/examples/ChangeUID" "~/Arduino/libraries/MFRC522/examples/DumpInfo" "~/Arduino/libraries/MFRC522/examples/FixBrickedUID" "~/Arduino/libraries/MFRC522/examples/MifareClassicValueBlock" "~/Arduino/libraries/MFRC522/examples/MinimalInterrupt" "~/Arduino/libraries/MFRC522/examples/Ntag216_AUTH" "~/Arduino/libraries/MFRC522/examples/RFID-Cloner" "~/Arduino/libraries/MFRC522/examples/ReadAndWrite" "~/Arduino/libraries/MFRC522/examples/ReadNUID" "~/Arduino/libraries/MFRC522/examples/ReadUidMultiReader" "~/Arduino/libraries/MFRC522/examples/firmware_check" "~/Arduino/libraries/MFRC522/examples/rfid_default_keys" "~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data" "~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data" "~/Arduino/libraries/WiFi101/examples"'
 
     strategy:
       fail-fast: false
@@ -79,11 +79,7 @@ jobs:
           - board:
               fqbn: '"arduino:samd:mkrwan1300" "arduino:samd:mkrwan1310"'
             additional-sketch-paths: "~/Arduino/libraries/MKRWAN/examples"
-          # WiFi101
-          - board:
-              type: "usb"
-            additional-sketch-paths: "~/Arduino/libraries/WiFi101/examples"
-          
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -109,6 +105,8 @@ jobs:
         with:
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |
+            - source-url: https://github.com/giulcioffi/WiFi101.git
+              version: namespaced_api
             - name: MFRC522
             - name: Arduino_MKRMEM
             - name: FlashStorage
@@ -130,7 +128,6 @@ jobs:
             - name: Arduino_LSM6DS3
             - name: Stepper
             - name: SD
-            - name: WiFi101
             - name: Arduino_JSON
             - name: Arduino_HTS221
             - name: Firmata
@@ -154,7 +151,6 @@ jobs:
             - name: MKRGSM
             - name: MKRNB
             - name: MKRWAN
-            - name: WiFi101
           platforms: |
             # Use Board Manager to install the latest release of Arduino megaAVR Boards to get the toolchain
             - name: "arduino:samd"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -181,8 +181,14 @@ jobs:
           repository: arduino/ArduinoCore-API
           path: extras/ArduinoCore-API
 
+      - name: Check if API should be compiled in the core
+        id: checkapi
+        run: |
+          if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
+
       - name: Install ArduinoCore-API
         run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
+        if: steps.checkapi.outputs.IS_API == 'true'
 
       - name: Checkout Basic examples
         uses: actions/checkout@v2

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,13 @@
+name: Report PR Size Deltas
+
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/actions/libraries/report-size-deltas@master

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -10,4 +10,4 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@main


### PR DESCRIPTION
In order to test that the ArduinoCore-API integration (#560 ) doesn't break the compilation of the main libraries/examples, a workflow for CI has been put in place. The `compile-examples` workflow compiles:

- internal core libraries + examples
- some of the most used libraries + related examples
- all the basic examples provided in the Arduino IDE
- Memory usage information collection is always enabled and handled by the `report-size-deltas` workflow.