### PR TITLE
Action for core release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  core-pre-release-from-tag:
+    runs-on: ubuntu-latest
+
+    #container:
+      #image: arduino/arduino-cli:builder-1
+      #volumes:
+        # cache go dependencies across pipeline's steps
+       # - ${{ github.workspace }}/go:/go
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set env
+        run: echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Test
+        run: |
+          echo $TAG_VERSION
+          echo ${{ env.TAG_VERSION }}
+
+      - name: Package the new core
+        run: |
+          extras/pack.release.bash $TAG_VERSION
+          mkdir staging
+          mv *.json staging/
+          mv *.tar.bz2 staging/
+
+      - name: Upload package_*_index.json file to Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "staging/*.json*"
+          PLUGIN_TARGET: "/packages/staging/"
+          #PLUGIN_STRIP_PREFIX: "staging/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Upload *.tar.bz2 of new core to Arduino downloads servers
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: "staging/*tar.bz2"
+          PLUGIN_TARGET: "/cores/staging/"
+          #PLUGIN_STRIP_PREFIX: "staging/"
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Checkout Basic examples
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/arduino-examples
+          path: extras
+
+      - name: skjgs
+        run: |
+          ./arduino-cli version
+          export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/staging/package_new_tag_${{ env.TAG_VERSION }}_index.json
+          ./arduino-cli config init --additional-urls https://downloads.arduino.cc/packages/package_staging_index.json
+          ./arduino-cli config dump --verbose
+          ./arduino-cli core update-index
+          ./arduino-cli core download arduino:samd --additional-urls http://downloads.arduino.cc/packages/staging/package_new_tag_${VERSION}_index.json -v
+          ./arduino-cli core install arduino:samd@${VERSION}
+          ./arduino-cli core update-index
+          ./arduino-cli board listall
+          ./arduino-cli compile --fqbn arduino:samd:mkrwan1300 extras/examples/01.Basics/Blink -v

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,66 +9,90 @@ jobs:
   core-pre-release-from-tag:
     runs-on: ubuntu-latest
 
-    #container:
-      #image: arduino/arduino-cli:builder-1
-      #volumes:
-        # cache go dependencies across pipeline's steps
-       # - ${{ github.workspace }}/go:/go
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          path: core-repo
+
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          path: ArduinoCore-API
 
       - name: Set env
         run: echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Test
+      - name: Get repo name
+        run: echo "REPOSITORY_NAME=$(echo ${{ github.repository }} | cut -d "/" -f2-)" >> $GITHUB_ENV
+
+      - name: Rename core-repo path
         run: |
-          echo $TAG_VERSION
-          echo ${{ env.TAG_VERSION }}
+          mv core-repo ${REPOSITORY_NAME}
 
       - name: Package the new core
         run: |
-          extras/pack.release.bash $TAG_VERSION
+          cd ${REPOSITORY_NAME}
+          echo $PWD
+          extras/pack.release.bash $TAG_VERSION $REPOSITORY_NAME
+          cd extras
           mkdir staging
-          mv *.json staging/
-          mv *.tar.bz2 staging/
+          echo $PWD
+          mv ../*.json staging/
+          mv ../*.tar.bz2 staging/
+          cd ../..
 
-      - name: Upload package_*_index.json file to Arduino downloads servers
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: "staging/*.json*"
-          PLUGIN_TARGET: "/packages/staging/"
-          #PLUGIN_STRIP_PREFIX: "staging/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Get architecture name
+        run: |
+          echo "ARCHITECTURE=$(cat ${REPOSITORY_NAME}/extras/package_index.json.NewTag.template | jq ".packages[0].platforms[0].architecture" | sed 's/\"//g')" >> $GITHUB_ENV
 
-      - name: Upload *.tar.bz2 of new core to Arduino downloads servers
-        uses: docker://plugins/s3
+      - name: Upload package_*_index.json and *.tar.bz2 file to Arduino downloads servers
         env:
-          PLUGIN_SOURCE: "staging/*tar.bz2"
-          PLUGIN_TARGET: "/cores/staging/"
-          #PLUGIN_STRIP_PREFIX: "staging/"
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 sync ${REPOSITORY_NAME}/extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/packages/staging/ --exclude "*" --include *.json
+          aws s3 sync ${REPOSITORY_NAME}/extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/cores/staging/ --exclude "*" --include *.tar.bz2
 
       - name: Checkout Basic examples
         uses: actions/checkout@v2
         with:
           repository: arduino/arduino-examples
-          path: extras
+          path: extras/arduino-examples
 
-      - name: skjgs
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1.1.1
+        with:
+          version: "0.14.0"
+
+      - name: Verify new core
         run: |
-          ./arduino-cli version
-          export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=https://downloads.arduino.cc/packages/staging/package_new_tag_${{ env.TAG_VERSION }}_index.json
-          ./arduino-cli config init --additional-urls https://downloads.arduino.cc/packages/package_staging_index.json
-          ./arduino-cli config dump --verbose
-          ./arduino-cli core update-index
-          ./arduino-cli core download arduino:samd --additional-urls http://downloads.arduino.cc/packages/staging/package_new_tag_${VERSION}_index.json -v
-          ./arduino-cli core install arduino:samd@${VERSION}
-          ./arduino-cli core update-index
-          ./arduino-cli board listall
-          ./arduino-cli compile --fqbn arduino:samd:mkrwan1300 extras/examples/01.Basics/Blink -v
+          export PATH=$PATH:$PWD
+          arduino-cli version
+          cp ${REPOSITORY_NAME}/extras/staging/package_${REPOSITORY_NAME}_${TAG_VERSION}_index.json .
+          export ARDUINO_DIRECTORIES_DATA=$PWD
+          export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=file://$PWD/package_${REPOSITORY_NAME}_${TAG_VERSION}_index.json
+          arduino-cli config init
+          arduino-cli config dump -v
+          arduino-cli core update-index -v
+          arduino-cli core install arduino:${ARCHITECTURE}@${TAG_VERSION}
+          INDEX=0
+          arduino-cli board listall --format=json > boardlist.json
+          N=$(jq '.boards | length' boardlist.json)
+          let N=N-1
+          echo $N
+          for INDEX in $(seq 0 1 $N); do arduino-cli compile --fqbn $(cat boardlist.json | jq ".boards[$INDEX].FQBN" | sed 's/\"//g') $PWD/extras/arduino-examples/examples/01.Basics/Blink; done
+
+      # See: https://github.com/rtCamp/action-slack-notify
+      - name: Slack notification of core pre-release
+        uses: rtCamp/action-slack-notify@v2.1.0
+        env:
+          SLACK_CHANNEL: core_releases
+          SLACK_COLOR: good
+          SLACK_USERNAME: ArduinoBot
+          SLACK_ICON: https://github.com/arduino.png?size=48
+          SLACK_TITLE: Arduino core pre-release
+          SLACK_MESSAGE: 'Version ${{ env.TAG_VERSION }} of core ${{ env.REPOSITORY_NAME }} is now available'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          MSG_MINIMAL: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          path: core-repo
-
-      - name: Checkout ArduinoCore-API
-        uses: actions/checkout@v2
-        with:
-          repository: arduino/ArduinoCore-API
-          path: ArduinoCore-API
 
       - name: Set env
         run: echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -27,33 +19,27 @@ jobs:
       - name: Get repo name
         run: echo "REPOSITORY_NAME=$(echo ${{ github.repository }} | cut -d "/" -f2-)" >> $GITHUB_ENV
 
-      - name: Rename core-repo path
-        run: |
-          mv core-repo ${REPOSITORY_NAME}
-
       - name: Package the new core
         run: |
-          cd ${REPOSITORY_NAME}
-          echo $PWD
           extras/pack.release.bash $TAG_VERSION $REPOSITORY_NAME
           cd extras
           mkdir staging
           echo $PWD
           mv ../*.json staging/
           mv ../*.tar.bz2 staging/
-          cd ../..
+          cd ..
 
       - name: Get architecture name
         run: |
-          echo "ARCHITECTURE=$(cat ${REPOSITORY_NAME}/extras/package_index.json.NewTag.template | jq ".packages[0].platforms[0].architecture" | sed 's/\"//g')" >> $GITHUB_ENV
+          echo "ARCHITECTURE=$(cat extras/package_index.json.NewTag.template | jq ".packages[0].platforms[0].architecture" | sed 's/\"//g')" >> $GITHUB_ENV
 
       - name: Upload package_*_index.json and *.tar.bz2 file to Arduino downloads servers
         env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 sync ${REPOSITORY_NAME}/extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/packages/staging/ --exclude "*" --include *.json
-          aws s3 sync ${REPOSITORY_NAME}/extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/cores/staging/ --exclude "*" --include *.tar.bz2
+          aws s3 sync extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/packages/staging/ --exclude "*" --include *.json
+          aws s3 sync extras/staging/ s3://${{ secrets.ARDUINO_DOWNLOADS_BUCKET }}/cores/staging/ --exclude "*" --include *.tar.bz2
 
       - name: Checkout Basic examples
         uses: actions/checkout@v2
@@ -66,17 +52,35 @@ jobs:
         with:
           version: "0.14.0"
 
-      - name: Verify new core
+      - name: Download new core
         run: |
           export PATH=$PATH:$PWD
           arduino-cli version
-          cp ${REPOSITORY_NAME}/extras/staging/package_${REPOSITORY_NAME}_${TAG_VERSION}_index.json .
+          cp extras/staging/package_${REPOSITORY_NAME}_${TAG_VERSION}_index.json .
           export ARDUINO_DIRECTORIES_DATA=$PWD
           export ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS=file://$PWD/package_${REPOSITORY_NAME}_${TAG_VERSION}_index.json
           arduino-cli config init
           arduino-cli config dump -v
           arduino-cli core update-index -v
           arduino-cli core install arduino:${ARCHITECTURE}@${TAG_VERSION}
+
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          path: extras/ArduinoCore-API
+
+      - name: Check if API should be compiled in the core
+        id: checkapi
+        run: |
+          if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
+
+      - name: Integrate ArduinoCore-API
+        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/packages/arduino/hardware/${ARCHITECTURE}/${TAG_VERSION}/cores/arduino"
+        if: steps.checkapi.outputs.IS_API == 'true'
+
+      - name: Verify new core
+        run: |
           INDEX=0
           arduino-cli board listall --format=json > boardlist.json
           N=$(jq '.boards | length' boardlist.json)

--- a/extras/pack.release.bash
+++ b/extras/pack.release.bash
@@ -19,7 +19,9 @@
 
 # Version check removed because version string passed from jenkins was incorrect
 VERSION_FROM_TAG=$1
+CORE_NAME=$2
 echo $VERSION_FROM_TAG
+echo $CORE_NAME
 VERSION=`grep version= platform.txt | sed 's/version=//g'`
 echo $VERSION
 
@@ -30,13 +32,14 @@ fi
 PWD=`pwd`
 FOLDERNAME=`basename $PWD`
 THIS_SCRIPT_NAME=`basename $0`
-FILENAME=core-new-tag-$VERSION.tar.bz2
+FILENAME=core-$CORE_NAME-$VERSION.tar.bz2
+echo $FILENAME
 
-rm -f samd-$VERSION.tar.bz2
-rm -f core-new-tag-$VERSION.tar.bz2
+rm -f *.tar.bz2
+rm -f *.json
 
 cd ..
-tar  --exclude=extras/** --exclude=.git* --exclude=.idea -cjf $FILENAME $FOLDERNAME
+tar  --exclude=extras/** --exclude=.git* --exclude=.idea -cjhf $FILENAME $FOLDERNAME
 cd -
 
 mv ../$FILENAME .
@@ -50,7 +53,4 @@ cat extras/package_index.json.NewTag.template |
 sed "s/%%VERSION%%/${VERSION}/" |
 sed "s/%%FILENAME%%/${FILENAME}/" |
 sed "s/%%CHECKSUM%%/${CHKSUM}/" |
-sed "s/%%SIZE%%/${SIZE}/" > package_new_tag_${VERSION}_index.json
-
-echo "${VERSION}"
-
+sed "s/%%SIZE%%/${SIZE}/" > package_${CORE_NAME}_${VERSION}_index.json

--- a/extras/package_index.json.NewTag.template
+++ b/extras/package_index.json.NewTag.template
@@ -1,0 +1,127 @@
+{
+  "packages": [
+    {
+      "name": "arduino",
+      "maintainer": "Arduino Betatesting",
+      "websiteURL": "http://www.arduino.cc/",
+      "email": "packages@arduino.cc",
+      "help": {
+        "online": "http://www.arduino.cc/en/Reference/HomePage"
+      },
+      "platforms": [
+        {
+          "name": "Arduino SAMD Boards (32-bits ARM Cortex-M0+) - Pre-release",
+          "architecture": "samd",
+          "version": "%%VERSION%%",
+          "category": "Arduino",
+          "help": {
+            "online": "http://www.arduino.cc/en/Reference/HomePage"
+          },
+          "url": "http://downloads.arduino.cc/cores/staging/%%FILENAME%%",
+          "archiveFileName": "%%FILENAME%%",
+          "checksum": "SHA-256:%%CHECKSUM%%",
+          "size": "%%SIZE%%",
+          "boards": [
+            { "name": "Arduino MKR WiFi 1010" },
+            { "name": "Arduino Zero" },
+            { "name": "Arduino MKR1000" },
+            { "name": "Arduino MKRZERO" },
+            { "name": "Arduino MKR FOX 1200" },
+            { "name": "Arduino MKR WAN 1300" },
+            { "name": "Arduino MKR WAN 1310" },
+            { "name": "Arduino MKR GSM 1400" },
+            { "name": "Arduino MKR NB 1500" },
+            { "name": "Arduino MKR Vidor 4000" },
+            { "name": "Arduino Nano 33 IoT" },
+            { "name": "Arduino M0 Pro" },
+            { "name": "Arduino M0" },
+            { "name": "Arduino Tian" },
+            { "name": "Adafruit Circuit Playground Express" }
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "arm-none-eabi-gcc",
+              "version": "7-2017q4"
+            },
+            {
+              "packager": "arduino",
+              "name": "bossac",
+              "version": "1.7.0-arduino3"
+            },
+            {
+              "packager": "arduino",
+              "name": "openocd",
+              "version": "0.10.0-arduino7"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS",
+              "version": "4.5.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "CMSIS-Atmel",
+              "version": "1.2.0"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.2.1"
+            }
+          ]
+        }
+      ],
+      "tools": [
+        {
+          "name": "arm-none-eabi-gcc",
+          "version": "7-2017q4",
+          "systems": [
+            {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
+              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b",
+              "size": "96613739"
+            },
+            {
+              "host": "aarch64-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
+              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
+              "size": "99558726"
+            },
+            {
+              "host": "i686-mingw32",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
+              "checksum": "SHA-256:96dd0091856f4d2eb21046eba571321feecf7d50b9c156f708b2a8b683903382",
+              "size": "131761924"
+            },
+            {
+              "host": "x86_64-apple-darwin",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
+              "checksum": "SHA-256:89b776c7cf0591c810b5b60067e4dc113b5b71bc50084a536e71b894a97fdccb",
+              "size": "104550003"
+            },
+            {
+              "host": "x86_64-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
+              "checksum": "SHA-256:96a029e2ae130a1210eaa69e309ea40463028eab18ba19c1086e4c2dafe69a6a",
+              "size": "99857645"
+            },
+            {
+              "host": "i686-pc-linux-gnu",
+              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
+              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3",
+              "size": "97427309"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/extras/package_index.json.NewTag.template
+++ b/extras/package_index.json.NewTag.template
@@ -73,54 +73,6 @@
         }
       ],
       "tools": [
-        {
-          "name": "arm-none-eabi-gcc",
-          "version": "7-2017q4",
-          "systems": [
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2019-q4-major-linuxarm.tar.bz2",
-              "checksum": "SHA-256:34180943d95f759c66444a40b032f7dd9159a562670fc334f049567de140c51b",
-              "size": "96613739"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linuxarm64.tar.bz2",
-              "checksum": "SHA-256:6fb5752fb4d11012bd0a1ceb93a19d0641ff7cf29d289b3e6b86b99768e66f76",
-              "size": "99558726"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-win32-arduino1.zip",
-              "checksum": "SHA-256:96dd0091856f4d2eb21046eba571321feecf7d50b9c156f708b2a8b683903382",
-              "size": "131761924"
-            },
-            {
-              "host": "x86_64-apple-darwin",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2",
-              "checksum": "SHA-256:89b776c7cf0591c810b5b60067e4dc113b5b71bc50084a536e71b894a97fdccb",
-              "size": "104550003"
-            },
-            {
-              "host": "x86_64-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2017-q4-major-linux64.tar.bz2",
-              "checksum": "SHA-256:96a029e2ae130a1210eaa69e309ea40463028eab18ba19c1086e4c2dafe69a6a",
-              "size": "99857645"
-            },
-            {
-              "host": "i686-pc-linux-gnu",
-              "url": "http://downloads.arduino.cc/tools/gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "archiveFileName": "gcc-arm-none-eabi-7-2018-q2-update-linux32.tar.bz2",
-              "checksum": "SHA-256:090a0bc2b1956bc49392dff924a6c30fa57c88130097b1972204d67a45ce3cf3",
-              "size": "97427309"
-            }
-          ]
-        }
       ]
     }
   ]


### PR DESCRIPTION
This GitHub action provides an automatic way to prepare an Arduino core pre-release:
- runs when a new tag with format [0-9].[0-9].[0-9]* is pushed
- checks that the tag is equal to the version in platform.txt
- generates the `package_ArduinoCore-samd_%VERSION%_index.json` and uploads it to a staging folder of the server
- creates `core-ArduinoCore-samd-%VERSION%.tar.bz2` and uploads it to a staging folder of the server
- downloads the new core using arduino-cli
- compiles a Blink for all the supported boards
- writes a notification to the Arduino Slack channel #core_releases

The action is totally core-independent and can be used in any other Arduino core repository.

What needs to be done to complete the release:
- add the signature from Jenkins
- add the newly generated package index to the official package_index.json
- in AWS, move the files outside the staging folder

**NOTE**: the action uses 4 secrets that must be previously set in the repository.