### PR TITLE
Package the core with latest release of ArduinoCore-API 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,22 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get Latest Release
-        id: latest_API_version
-        uses: abatilo/release-info-action@v1.3.0
-        with:
-          owner: arduino
-          repo: ArduinoCore-API
-
-      - name: Set ArduinoCore-API latest version as env variable
-        run: |
-          echo "LATEST_TAG_API=$(echo ${{ steps.latest_API_version.outputs.latest_tag }})" >> $GITHUB_ENV
-
       - name: Checkout ArduinoCore-API
         uses: actions/checkout@v2
         with:
           repository: arduino/ArduinoCore-API
-          ref: ${{ env.LATEST_TAG_API }}
           path: extras/ArduinoCore-API
 
       - name: Check if API should be compiled in the core
@@ -36,8 +24,13 @@ jobs:
         run: |
           if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
 
-      - name: Integrate ArduinoCore-API
-        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
+      - name: Checkout latest tag of ArduinoCore-API and add it to the core
+        run: |
+          cd extras/ArduinoCore-API
+          git fetch --tags
+          git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
+          cd ../..
+          mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
         if: steps.checkapi.outputs.IS_API == 'true'
 
       - name: Remove ArduinoCore-API

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Get Latest Release
+        id: latest_API_version
+        uses: abatilo/release-info-action@v1.3.0
+        with:
+          owner: arduino
+          repo: ArduinoCore-API
+
+      - name: Set ArduinoCore-API latest version as env variable
+        run: |
+          echo "LATEST_TAG_API=$(echo ${{ steps.latest_API_version.outputs.latest_tag }})" >> $GITHUB_ENV
+
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          ref: ${{ env.LATEST_TAG_API }}
+          path: extras/ArduinoCore-API
+
+      - name: Check if API should be compiled in the core
+        id: checkapi
+        run: |
+          if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
+
+      - name: Integrate ArduinoCore-API
+        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"
+        if: steps.checkapi.outputs.IS_API == 'true'
+
+      - name: Remove ArduinoCore-API
+        run: rm -r "$GITHUB_WORKSPACE/extras/ArduinoCore-API"
+
       - name: Set env
         run: echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
@@ -52,7 +82,7 @@ jobs:
         with:
           version: "0.14.0"
 
-      - name: Download new core
+      - name: Download and verify new core
         run: |
           export PATH=$PATH:$PWD
           arduino-cli version
@@ -63,24 +93,6 @@ jobs:
           arduino-cli config dump -v
           arduino-cli core update-index -v
           arduino-cli core install arduino:${ARCHITECTURE}@${TAG_VERSION}
-
-      - name: Checkout ArduinoCore-API
-        uses: actions/checkout@v2
-        with:
-          repository: arduino/ArduinoCore-API
-          path: extras/ArduinoCore-API
-
-      - name: Check if API should be compiled in the core
-        id: checkapi
-        run: |
-          if [[ $(grep -r api platform.txt) ]]; then echo "::set-output name=IS_API::true"; fi
-
-      - name: Integrate ArduinoCore-API
-        run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/packages/arduino/hardware/${ARCHITECTURE}/${TAG_VERSION}/cores/arduino"
-        if: steps.checkapi.outputs.IS_API == 'true'
-
-      - name: Verify new core
-        run: |
           INDEX=0
           arduino-cli board listall --format=json > boardlist.json
           N=$(jq '.boards | length' boardlist.json)


### PR DESCRIPTION
This PR is related to #573. 
It allows to add (if required by `platform.txt`) the latest release of ArduinoCore-API in the new core that is going to be packaged.