### PR TITLE
Use authenticated API requests in "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -261,6 +261,7 @@ jobs:
             ${{ matrix.wan-sketch-paths }}
           enable-deltas-report: 'true'
           verbose: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
The `arduino/compile-sketches` GitHub Actions action used in the "Compile Examples" workflow queries the GitHub API for the base ref of the pull request, which is used for the memory deltas determination.

There were a couple workflow runs recently ([1](https://github.com/arduino/ArduinoCore-samd/runs/1568054352?check_suite_focus=true), [2](https://github.com/arduino/ArduinoCore-samd/runs/1569955293?check_suite_focus=true)) that failed due to rate limiting. Authenticated API requests are given a more generous API request allowance, so providing the action with [the automatically generated GitHub access token](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow) should prevent this from happening again.