### PR TITLE
Fix I2C Master hang when communicating with bad I2C slaves.

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -568,8 +568,8 @@ bool SERCOM::sendDataMasterWIRE(uint8_t data)
   while(!sercom->I2CM.INTFLAG.bit.MB) {
 
     // If a bus error occurs, the MB bit may never be set.
-    // Check the bus error bit and bail if it's set.
-    if (sercom->I2CM.STATUS.bit.BUSERR) {
+    // Check the bus error bit and ARBLOST bit and bail if either is set.
+    if (sercom->I2CM.STATUS.bit.BUSERR || sercom->I2CM.STATUS.bit.ARBLOST) {
       return false;
     }
   }


### PR DESCRIPTION
Added check for ARBLOST in sendDataMasterWIRE so misbehaving I2C slaves don't cause the Zero to get stuck in an endless loop.
I had a case where an I2C slave would just pull SDA low and never allow the transaction to complete. While this is definitely bad behavior on the I2C slave, it would cause the Zero I2C master to get stuck in the while loop with no chance to exit. In this case, ARBLOST was set (due to the low SDA and the first high I2C address bit mismatching), so I could use that to prematurely exit the loop.