### PR TITLE
Add a weak attribute to serial IRQ allowing real time communication lib.

### DIFF
--- a/variants/arduino_mzero/variant.cpp
+++ b/variants/arduino_mzero/variant.cpp
@@ -212,12 +212,12 @@ SERCOM sercom5( SERCOM5 ) ;
 
 Uart Serial1( &sercom0, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
 Uart Serial( &sercom5, PIN_SERIAL_RX, PIN_SERIAL_TX, PAD_SERIAL_RX, PAD_SERIAL_TX ) ;
-void SERCOM0_Handler()
+__attribute__((weak)) void SERCOM0_Handler()
 {
   Serial1.IrqHandler();
 }
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial.IrqHandler();
 }

--- a/variants/arduino_zero/variant.cpp
+++ b/variants/arduino_zero/variant.cpp
@@ -221,12 +221,12 @@ SERCOM sercom5( SERCOM5 ) ;
 
 Uart Serial1( &sercom0, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
 Uart Serial( &sercom5, PIN_SERIAL_RX, PIN_SERIAL_TX, PAD_SERIAL_RX, PAD_SERIAL_TX ) ;
-void SERCOM0_Handler()
+__attribute__((weak)) void SERCOM0_Handler()
 {
   Serial1.IrqHandler();
 }
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial.IrqHandler();
 }

--- a/variants/circuitplay/variant.cpp
+++ b/variants/circuitplay/variant.cpp
@@ -149,7 +149,7 @@ const PinDescription g_APinDescription[]=
   { PORTA, 11, PIO_ANALOG, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG), ADC_Channel19, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_11 },                      // A8 / Light Sensor
   { PORTA,  9, PIO_ANALOG, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER|PIN_ATTR_ANALOG), ADC_Channel17, PWM0_CH1, TCC0_CH1, EXTERNAL_INT_9 }, // A9 / Thermistor
   { PORTA,  4, PIO_ANALOG, (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG), ADC_Channel4, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_4 },          // A10 Proximity
-  
+
   // GPIO 25 / IR Transmit
   { PORTA, 23, PIO_DIGITAL, (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER), No_ADC_Channel, PWM4_CH1, TC4_CH1, EXTERNAL_INT_7 },  // GPIO D25 - IR Transmitter
   // GPIO 26 / IR Remote in
@@ -177,7 +177,7 @@ const PinDescription g_APinDescription[]=
 
 
   // 36..38 - USB
-  // --------------------  
+  // --------------------
   { PORTA, 22, PIO_SERCOM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // GPIO 29 - Host USB (not used)
   { PORTA, 24, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB/DM
   { PORTA, 25, PIO_COM, PIN_ATTR_NONE, No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // USB/DP
@@ -202,7 +202,7 @@ SERCOM sercom5( SERCOM5 ) ;
 
 Uart Serial1( &sercom4, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX ) ;
 
-void SERCOM4_Handler()
+__attribute__((weak)) void SERCOM4_Handler()
 {
   Serial1.IrqHandler();
 }

--- a/variants/mkr1000/variant.cpp
+++ b/variants/mkr1000/variant.cpp
@@ -179,7 +179,7 @@ SERCOM sercom5(SERCOM5);
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }

--- a/variants/mkrfox1200/variant.cpp
+++ b/variants/mkrfox1200/variant.cpp
@@ -149,7 +149,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM_ALT, (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM4/PAD[3]
   { PORTA, 27, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
-  
+
   { PORTA, 28, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  8, PIO_ANALOG,     (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG             ), ADC_Channel2,   NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_ANALOG,     (PIN_ATTR_PWM|PIN_ATTR_TIMER                  ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
@@ -177,7 +177,7 @@ SERCOM sercom5(SERCOM5);
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }

--- a/variants/mkrgsm1400/variant.cpp
+++ b/variants/mkrgsm1400/variant.cpp
@@ -151,7 +151,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM4/PAD[3]
   { PORTA, 27, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_15 },
-  
+
   { PORTB,  8, PIO_DIGITAL,    (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG             ), ADC_Channel2,   NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_ANALOG,     (PIN_ATTR_PWM|PIN_ATTR_TIMER                  ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
 
@@ -261,7 +261,7 @@ void initVariant() {
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }
@@ -269,7 +269,7 @@ void SERCOM5_Handler()
 // SerialGSM
 Uart Serial2(&sercom4, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX, PIN_SERIAL2_RTS, PIN_SERIAL2_CTS);
 
-void SERCOM4_Handler()
+__attribute__((weak)) void SERCOM4_Handler()
 {
   Serial2.IrqHandler();
 }

--- a/variants/mkrnb1500/variant.cpp
+++ b/variants/mkrnb1500/variant.cpp
@@ -151,7 +151,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM_ALT, (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM4/PAD[3]
   { PORTA, 27, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_15 },
-  
+
   { PORTB,  8, PIO_DIGITAL,    (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG             ), ADC_Channel2,   NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_ANALOG,     (PIN_ATTR_PWM|PIN_ATTR_TIMER                  ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
 
@@ -265,7 +265,7 @@ void initVariant() {
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }
@@ -273,7 +273,7 @@ void SERCOM5_Handler()
 // SerialSARA
 Uart Serial2(&sercom4, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX);
 
-void SERCOM4_Handler()
+__attribute__((weak)) void SERCOM4_Handler()
 {
   Serial2.IrqHandler();
 }

--- a/variants/mkrvidor4000/variant.cpp
+++ b/variants/mkrvidor4000/variant.cpp
@@ -151,7 +151,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_DIGITAL,    (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM,     (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM2/PAD[3]
   { PORTA, 27, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
-  
+
   { PORTA, 28, PIO_DIGITAL,    (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  8, PIO_DIGITAL,    (PIN_ATTR_DIGITAL                             ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_DIGITAL,    (PIN_ATTR_DIGITAL|PIN_ATTR_PWM|PIN_ATTR_TIMER ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
@@ -251,7 +251,7 @@ SERCOM sercom5(SERCOM5);
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }

--- a/variants/mkrwan1300/variant.cpp
+++ b/variants/mkrwan1300/variant.cpp
@@ -153,7 +153,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_DIGITAL,     (PIN_ATTR_NONE                               ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM_ALT,  (PIN_ATTR_NONE                               ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM4/PAD[3]
   { PORTA, 27, PIO_DIGITAL,     (PIN_ATTR_NONE                               ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
-  
+
   { PORTA, 28, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_8    },
   { PORTB,  8, PIO_ANALOG,     (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG             ), ADC_Channel2,   NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_DIGITAL,    (PIN_ATTR_PWM|PIN_ATTR_TIMER                  ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
@@ -267,7 +267,7 @@ SERCOM sercom5(SERCOM5);
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }
@@ -275,7 +275,7 @@ void SERCOM5_Handler()
 // SerialLoRa
 Uart Serial2(&sercom4, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX);
 
-void SERCOM4_Handler()
+__attribute__((weak)) void SERCOM4_Handler()
 {
   Serial2.IrqHandler();
 }

--- a/variants/mkrwifi1010/variant.cpp
+++ b/variants/mkrwifi1010/variant.cpp
@@ -151,7 +151,7 @@ const PinDescription g_APinDescription[] = {
   { PORTA, 14, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // SS:   as GPIO
   { PORTA, 15, PIO_SERCOM_ALT, (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE }, // MISO: SERCOM4/PAD[3]
   { PORTA, 27, PIO_DIGITAL,    (PIN_ATTR_NONE                                ), No_ADC_Channel, NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_15 },
-  
+
   { PORTB,  8, PIO_DIGITAL,    (PIN_ATTR_DIGITAL|PIN_ATTR_ANALOG             ), ADC_Channel2,   NOT_ON_PWM, NOT_ON_TIMER, EXTERNAL_INT_NONE },
   { PORTB,  9, PIO_ANALOG,     (PIN_ATTR_PWM|PIN_ATTR_TIMER                  ), ADC_Channel3,   PWM4_CH1,   TC4_CH1,      EXTERNAL_INT_9    },
 
@@ -244,7 +244,7 @@ void initVariant() {
 // Serial1
 Uart Serial1(&sercom5, PIN_SERIAL1_RX, PIN_SERIAL1_TX, PAD_SERIAL1_RX, PAD_SERIAL1_TX);
 
-void SERCOM5_Handler()
+__attribute__((weak)) void SERCOM5_Handler()
 {
   Serial1.IrqHandler();
 }
@@ -252,7 +252,7 @@ void SERCOM5_Handler()
 // Serial2
 Uart Serial2(&sercom4, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX, PIN_SERIAL2_RTS, PIN_SERIAL2_CTS);
 
-void SERCOM4_Handler()
+__attribute__((weak)) void SERCOM4_Handler()
 {
   Serial2.IrqHandler();
 }

--- a/variants/nano_33_iot/variant.cpp
+++ b/variants/nano_33_iot/variant.cpp
@@ -194,14 +194,14 @@ void SERCOM5_Handler()
 
 Uart Serial2(&sercom3, PIN_SERIAL2_RX, PIN_SERIAL2_TX, PAD_SERIAL2_RX, PAD_SERIAL2_TX);
 
-void SERCOM3_Handler()
+__attribute__((weak)) void SERCOM3_Handler()
 {
   Serial2.IrqHandler();
 }
 
 Uart SerialHCI(&sercom2, PIN_SERIALHCI_RX, PIN_SERIALHCI_TX, PAD_SERIALHCI_RX, PAD_SERIALHCI_TX, PIN_SERIALHCI_RTS, PIN_SERIALHCI_CTS);
 
-void SERCOM2_Handler()
+__attribute__((weak)) void SERCOM2_Handler()
 {
   SerialHCI.IrqHandler();
 }


### PR DESCRIPTION
There is no way to have a complexe software communication protocol without IRQ.
Arduino should comply with it allowing real time constraints protocols.

The best way could be to be able to avoid Serial object creation and call a custom object into IRQ, but I can't find any way to do it without breaking everything.

Another good way could be to make something like an attach_interrupt function on Serial object. But it's not really standard into Arduino ecosystem and impact everyone with a little bit more CPU time on each byte reception for the benefits of some specific guys like me.

The last way is to declare IRQ as weak allowing someone to take the lead on IRQ. In this case, there is a dead Serial object but this modification doesn't do anything in any other case and the custom serial lib developper is the guilty one.