### PR TITLE
Pin Ace* libraries at last compatible version in CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -248,7 +248,8 @@ jobs:
             - name: LoRa
             - name: MKRWAN
             - name: WiFiNINA
-            - name: AceTime
+            - name: AceTime@1.4.1
+            - name: AceCommon@1.3.1
             - source-url: https://github.com/vidor-libraries/VidorPeripherals.git
           platforms: |
             # Use Board Manager to install the latest release of Arduino SAMD Boards to get the toolchain


### PR DESCRIPTION
Due to incompatibilities introduced during the initial ArduinoCore-API incorporation (https://github.com/arduino/ArduinoCore-samd/issues/587), the author of the AceTime and AceCommon libraries has added an #error directive that is triggered when the libraries are compiled by any version of `arduino:samd` that uses ArduinoCore-API :

- https://github.com/bxparks/AceTime/issues/45
- https://github.com/bxparks/AceCommon/issues/9

Ironically, compilation of the AceTime example sketch was added with the goal of avoiding any future breakage of compatibility with that library (https://github.com/arduino/ArduinoCore-samd/pull/588).

Pinning the libraries to the version before the intentional breakage of compatibility by the libraries gets us back to the sketch compilations failing due to the original unintentional breakage by `arduino:samd`.

Closes https://github.com/arduino/ArduinoCore-samd/issues/606 (CC: @stonehippo)