### PR TITLE
Fix compiler warning from useless volatile

### DIFF
--- a/cores/arduino/Reset.cpp
+++ b/cores/arduino/Reset.cpp
@@ -28,7 +28,7 @@ extern "C" {
 #if (ARDUINO_SAMD_VARIANT_COMPLIANCE >= 10610)
 
 extern const uint32_t __text_start__;
-#define APP_START ((volatile uint32_t)(&__text_start__) + 4)
+#define APP_START ((uint32_t)(&__text_start__) + 4)
 
 #else
 #define APP_START 0x00002004


### PR DESCRIPTION
"Cast to integral type ignores qualifier volatile"

Attempting to cast to a `volatile uint32_t` does nothing different from cast to a `uint32_t`,
with the exception of looking like it's doing something different.

Just remove the `volatile` qualifier to fix.

See also https://github.com/adafruit/ArduinoCore-samd/pull/288