### PR TITLE
Disable verbose output in sketch compilation CI logs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -263,7 +263,7 @@ jobs:
             ${{ matrix.mkrgsm1400-sketch-paths }}
             ${{ matrix.wan-sketch-paths }}
           enable-deltas-report: 'true'
-          verbose: 'true'
+          verbose: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save memory usage change report as artifact


### PR DESCRIPTION
The `arduino/compile-sketches` action was previously configured for verbose output.. This option is primarily intended to be used for troubleshooting and doesn't contain any information that is useful for general usage.

Due to the extensive coverage of this CI workflow, the logs are massive, which makes it inconvenient for anyone to read them to identify the cause of a failure. Removing the verbose output will improve that situation