### PR TITLE
SafeRingBuffer.h: Prevent compiler warning about reaching end of non-void function (see #580)

### DIFF
--- a/cores/arduino/SafeRingBuffer.h
+++ b/cores/arduino/SafeRingBuffer.h
@@ -41,6 +41,12 @@ int SafeRingBufferN<N>::read_char() {
   synchronized {
     return RingBufferN<N>::read_char();
   }
+
+  // We should never reached this line because the synchronized {} block gets
+  // executed at least once. However the compiler gets confused and prints a
+  // warning about control reaching the end of a non-void function. This
+  // silences that warning.
+  return -1;
 }
 
 template <int N>


### PR DESCRIPTION
The compiler prints the following warning messages on `SafeRingBuffer.h`:

```
$ au --cli verify mkr1000 ArithmeticTest/
...
+ /home/brian/bin/linux/arduino-cli  compile  --fqbn arduino:samd:mkr1000  --warnings all --build-property 'compiler.cpp.extra_flags=-D AUNITER -D AUNITER_MKR1000 ' ArithmeticTest/ArithmeticTest.ino
In file included from /home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/cores/arduino/Uart.h:23:0,
                 from /home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/variants/mkr1000/variant.h:164,
                 from /home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/cores/arduino/Arduino.h:51,
                 from /home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/cores/arduino/Uart.cpp:19:
/home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/cores/arduino/SafeRingBuffer.h: In member function 'int arduino::SafeRingBufferN<N>::read_char() [with int N = 64]':
/home/brian/dev/arduino-1.8.13/portable/packages/arduino/hardware/samd/1.8.11/cores/arduino/SafeRingBuffer.h:44:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
```

The compiler cannot figure out that the end of the function will never be reached. This prevents the warning by adding a `return -1` at the end of the function.