### PR TITLE
Use established KEYWORD_TOKENTYPE for global instance keywords

### DIFF
--- a/libraries/SAMD_BootloaderUpdater/keywords.txt
+++ b/libraries/SAMD_BootloaderUpdater/keywords.txt
@@ -6,18 +6,14 @@
 # Datatypes (KEYWORD1)
 ################################################
 
+SAMD_BootloaderUpdater	KEYWORD2
+
 ################################################
 # Methods and Functions (KEYWORD2)
 ################################################
 
 needsUpdate	KEYWORD2
 update	KEYWORD2
-
-#######################################
-# Instances (KEYWORD2)
-#######################################
-
-SAMD_BootloaderUpdater	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -6,6 +6,9 @@
 # Datatypes (KEYWORD1)
 #######################################
 
+Wire	KEYWORD2
+Wire1	KEYWORD2
+
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -16,13 +19,6 @@ endTransmission	KEYWORD2
 requestFrom	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
-
-#######################################
-# Instances (KEYWORD2)
-#######################################
-
-Wire	KEYWORD2
-Wire1	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
All the other platform bundled libraries use `KEYWORD1` for the library's global instance so this provides consistency.

Fixes (in combination with equivalent PRs in the other boards platform repos) https://github.com/arduino/Arduino/issues/8538