### PR TITLE
Document SAMD_AnalogCorrection library's 12 bit resolution requirement

### DIFF
--- a/libraries/SAMD_AnalogCorrection/examples/CorrectADCResponse/CorrectADCResponse.ino
+++ b/libraries/SAMD_AnalogCorrection/examples/CorrectADCResponse/CorrectADCResponse.ino
@@ -18,7 +18,7 @@
   6) Open the Serial Monitor and press the reset button on the Arduino ZERO
   7) At the and of the procedure you can find logged
        - the offset and gain values for the board where the sketch has been just executed
-       - the instruction line to copy/paste in the final sketch
+       - the code to copy/paste in sketches using this library
 */
 
 #include "SAMD_AnalogCorrection.h"
@@ -32,7 +32,7 @@
 #define ADC_MIN_GAIN         0x0400
 #define ADC_UNITY_GAIN       0x0800
 #define ADC_MAX_GAIN         (0x1000 - 1)
-#define ADC_RESOLUTION_BITS  12
+#define ADC_RESOLUTION_BITS  12 // do not change. This library only supports 12 bit resolution.
 #define ADC_RANGE            (1 << ADC_RESOLUTION_BITS)
 #define ADC_TOP_VALUE        (ADC_RANGE - 1)
 
@@ -162,7 +162,8 @@ void setup()
   Serial.println(offsetCorrectionValue);
   Serial.print("   Gain = ");
   Serial.println(gainCorrectionValue);
-  Serial.println("\r\nAdd the next line to your sketch:");
+  Serial.println("\r\nAdd the next lines to your sketch:");
+  Serial.println("   analogReadResolution(12);");
   Serial.print("   analogReadCorrection(");
   Serial.print(offsetCorrectionValue);
   Serial.print(", ");


### PR DESCRIPTION
The platform bundled SAMD_AnalogCorrection library is only compatible with 12 bit ADC resolution. This can be confusing to the user because:

- The definition of `ADC_RESOLUTION_BITS` in the CorrectADCResponse sketch gives the impression this value can be modified by the user.
- The default `analogRead()` resolution [is 10 bits](https://www.arduino.cc/reference/en/language/functions/zero-due-mkr-family/analogreadresolution/).

The first is resolved by the addition of a comment prohibiting changing the value of `ADC_RESOLUTION_BITS`.

The second is resolved by the addition of an `analogReadResolution(12)` call to the code generated by the CorrectADCResponse sketch.

---
Closes https://github.com/arduino/ArduinoCore-samd/issues/608

CC: @hasenradball