### PR TITLE
Restructure programmers by removing hardcoded build.openocdscript

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -198,14 +198,14 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" -f "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "telnet_port disabled; program {{build.path}/{build.project_name}.bin} verify reset 0x2000; shutdown"
+tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" -f "interface/{protocol}" -c "set telnet_port 0" {extra_params} -f "target/at91samdXX.cfg" -c "telnet_port disabled; program {{build.path}/{build.project_name}.bin} verify reset 0x2000; shutdown"
 
 tools.openocd.network_cmd={runtime.tools.arduinoOTA.path}/bin/arduinoOTA
 tools.openocd.upload.network_pattern={network_cmd} -address {serial.port} -port 65280 -username arduino -password "{network.password}" -sketch "{build.path}/{build.project_name}.bin" -upload /sketch -b
 
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0
-tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -s "{path}/share/openocd/scripts/" -f "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "telnet_port disabled; program {{build.path}/{build.project_name}.hex} verify reset; shutdown"
+tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -s "{path}/share/openocd/scripts/" -f "interface/{protocol}" -c "set telnet_port 0" {extra_params} -f "target/at91samdXX.cfg" -c "telnet_port disabled; program {{build.path}/{build.project_name}.hex} verify reset; shutdown"
 
 tools.openocd.erase.params.verbose=-d3
 tools.openocd.erase.params.quiet=-d0
@@ -213,7 +213,7 @@ tools.openocd.erase.pattern=
 
 tools.openocd.bootloader.params.verbose=-d2
 tools.openocd.bootloader.params.quiet=-d0
-tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" -f "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "telnet_port disabled; init; halt; at91samd bootloader 0; program {{runtime.platform.path}/bootloaders/{bootloader.file}} verify reset; shutdown"
+tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" -f "interface/{protocol}" -c "set telnet_port 0" {extra_params} -f "target/at91samdXX.cfg" -c "telnet_port disabled; init; halt; at91samd bootloader 0; program {{runtime.platform.path}/bootloaders/{bootloader.file}} verify reset; shutdown"
 
 #
 # OpenOCD sketch upload - version with configurable bootloader size

--- a/programmers.txt
+++ b/programmers.txt
@@ -16,21 +16,24 @@
 
 edbg.name=Atmel EDBG
 edbg.communication=USB
-edbg.protocol=
-edbg.program.protocol=
+edbg.protocol=cmsis-dap.cfg
 edbg.program.tool=openocd
-edbg.program.extra_params=
+edbg.extra_params=
 
 atmel_ice.name=Atmel-ICE
 atmel_ice.communication=USB
-atmel_ice.protocol=
-atmel_ice.program.protocol=
+atmel_ice.protocol=cmsis-dap.cfg
 atmel_ice.program.tool=openocd
-atmel_ice.program.extra_params=
+atmel_ice.extra_params=
 
 sam_ice.name=Atmel SAM-ICE
 sam_ice.communication=USB
-sam_ice.protocol=
-sam_ice.program.protocol=
+sam_ice.protocol=cmsis-dap.cfg
 sam_ice.program.tool=openocd
-sam_ice.program.extra_params=
+sam_ice.extra_params=
+
+jlink.name=Segger J-Link
+jlink.communication=USB
+jlink.protocol=jlink.cfg
+jlink.program.tool=openocd
+jlink.extra_params=-c "transport select swd"


### PR DESCRIPTION
This allows selecting multiple programmers; J-Link added as an example.

@ubidefeo 