### PR TITLE
Fix bootloader not replying to SAM-BA commands if USB Reset happens

### DIFF
--- a/bootloaders/zero/board_driver_usb.c
+++ b/bootloaders/zero/board_driver_usb.c
@@ -281,6 +281,9 @@ uint8_t USB_IsConfigured(P_USB_CDC pCdc)
 
     // Reset current configuration value to 0
     pCdc->currentConfiguration = 0;
+
+    // Reset the read_job flag back to false
+    read_job = false;
   }
   else
   {


### PR DESCRIPTION
Steps to reproduce:

a) power up the board cold from a separate power supply,
b) plug in board to PC with USB cable, run bossac to say to hello to the Arduino; all good so far;
c) now unplug and replug the USB cable, while keeping the board powered,
d) notice that USB re-enumeration takes place OK, the device is still detected just fine by the PC;
e) however, if you now run bossac, it just hangs and gets no reply;

This is because the `read_job` flag does not get reset back to `false` when a USB Reset event occurs.