### PR TITLE
Advertise the board serial number in the USB descriptor when in the bootloader

### DIFF
--- a/bootloaders/zero/sam_ba_usb.h
+++ b/bootloaders/zero/sam_ba_usb.h
@@ -69,6 +69,7 @@
 #define STRING_INDEX_LANGUAGES         (0x00u)
 #define STRING_INDEX_MANUFACTURER      (0x01u)
 #define STRING_INDEX_PRODUCT           (0x02u)
+#define STRING_INDEX_SERIAL_NUMBER     (0x03u)
 
 #define SAM_BA_MIN(a, b) (((a) < (b)) ? (a) : (b))
 


### PR DESCRIPTION
This will prevent Windows from creating a new COM port if it already saw the previous serial number. Also handy if you have multiple Arduino devices plugged into the same system. Code was copy-pasted from the main ArduinoCore-samd implementation to get the serial number.