### PR TITLE
fix Serial.flush() blocks forever #597

### DIFF
--- a/cores/arduino/SERCOM.cpp
+++ b/cores/arduino/SERCOM.cpp
@@ -112,11 +112,10 @@ void SERCOM::enableUART()
 void SERCOM::flushUART()
 {
   // Skip checking transmission completion if data register is empty
-//   if(isDataRegisterEmptyUART())
-//     return;
+  // Wait for transmission to complete, if ok to do so.
+  while(!sercom->USART.INTFLAG.bit.TXC && onFlushWaitUartTXC);
 
-  // Wait for transmission to complete
-  while(!sercom->USART.INTFLAG.bit.TXC);
+  onFlushWaitUartTXC = false;
 }
 
 void SERCOM::clearStatusUART()
@@ -183,6 +182,10 @@ int SERCOM::writeDataUART(uint8_t data)
 
   //Put data into DATA register
   sercom->USART.DATA.reg = (uint16_t)data;
+
+  // indicate it's ok to wait for TXC flag when flushing
+  onFlushWaitUartTXC = true;
+
   return 1;
 }
 

--- a/cores/arduino/SERCOM.h
+++ b/cores/arduino/SERCOM.h
@@ -218,6 +218,11 @@ class SERCOM
 		uint8_t calculateBaudrateSynchronous(uint32_t baudrate) ;
 		uint32_t division(uint32_t dividend, uint32_t divisor) ;
 		void initClockNVIC( void ) ;
+
+		// Flag set when data is loaded into sercom->USART.DATA.reg.
+		// Helps with preventing UART lockups when flushing on startup
+		// and the asyncronous nature of the DRE and TXC interrupt flags.
+		bool onFlushWaitUartTXC = false;
 };
 
 #endif


### PR DESCRIPTION
* The aynchronous nature of the DRE and TXC interrupt flags
  causes issues (lockups) when the TX DATA register is empty on start
  and a flush is issued. Simply looking at the DRE prior to
  waiting for TXC is insufficient because the data register
  may well be empty but the shift register could still contain
  data, in this case SERCOM::flushUART() would return before TXC
  has been raised thus before flushing is complete.
* bool added to SERCOM.h to indicate when it is ok for
  SERCOM::flushUART() to wait for the TXC flag. This flag is
  set when any data is written to the data register via
  SERCOM::writeDataUART(). It is cleared when a flush is done.

Fixes #597