### PR TITLE
Remove programmer properties from openocd upload pattern

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -202,7 +202,7 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" -f "interface/{protocol}" -c "set telnet_port 0" {extra_params} -f "target/at91samdXX.cfg" -c "telnet_port disabled; program {{build.path}/{build.project_name}.bin} verify reset 0x2000; shutdown"
+tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" -f "{runtime.platform.path}/variants/{build.variant}/{build.openocdscript}" -c "telnet_port disabled; program {{build.path}/{build.project_name}.bin} verify reset 0x2000; shutdown"
 
 # the following rule is deprecated by pluggable discovery
 tools.openocd.upload.network_pattern={tools.arduino_ota.cmd} -address {serial.port} -port 65280 -username arduino -password "{network.password}" -sketch "{build.path}/{build.project_name}.bin" -upload /sketch -b


### PR DESCRIPTION
Platform properties may be associated with a specific programmer selection in the [`programmers.txt` configuration file](https://arduino.github.io/arduino-cli/dev/platform-specification/#programmerstxt). These properties can be used in the `platform.txt` patterns for the actions that use the programmer:

- [`program`](https://arduino.github.io/arduino-cli/dev/platform-specification/#upload-using-an-external-programmer)
- [`erase`](https://arduino.github.io/arduino-cli/dev/platform-specification/#burn-bootloader)
- [`bootloader`](https://arduino.github.io/arduino-cli/dev/platform-specification/#burn-bootloader)

However, those properties are not expanded in the [`upload`](https://arduino.github.io/arduino-cli/dev/platform-specification/#sketch-upload-configuration) pattern, since it does not use the programmer:

https://arduino.github.io/arduino-cli/dev/platform-specification/#programmerstxt

> These properties can only be used in the recipes of the actions that use the programmer (`erase`, `bootloader`, and `program`).

While enhancing the ability to make programmer-specific configuration of the patterns (https://github.com/arduino/ArduinoCore-samd/pull/636), programmer-associated properties were introduced into `tools.openocd.upload.pattern`, which caused uploads to fail for the "Arduino Zero (Programming Port)" board:

```
Unexpected command line argument: {extra_params}
```

The `upload` pattern is hereby reverted to the previous working configuration, leaving [the beneficial changes](https://github.com/arduino/ArduinoCore-samd/pull/636) to the other patterns.

---
Originally reported at https://forum.arduino.cc/t/unexpected-command-line-argument-extra-params/929834