### PR TITLE
Fix USBDevice.connected()

### DIFF
--- a/cores/arduino/USB/USBCore.cpp
+++ b/cores/arduino/USB/USBCore.cpp
@@ -480,8 +480,8 @@ void USBDeviceClass::stall(uint32_t ep)
 bool USBDeviceClass::connected()
 {
 	// Count frame numbers
-	uint8_t f = USB->DEVICE.FNUM.bit.FNUM;
-	//delay(3);
+	uint16_t f = USB->DEVICE.FNUM.bit.FNUM;
+	delay(1); // wait for next SOF
 	return f != USB->DEVICE.FNUM.bit.FNUM;
 }
 


### PR DESCRIPTION
* Fix arduino/ArduinoCore-samd#661
* connected() did not return the USB connected state, but essentially a
  random value.