### PR TITLE
Fixed Serial_::begin(..) definition to match arduino::HardwareSerial

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -196,12 +196,12 @@ void Serial_::enableInterrupt() {
 	usbd.epBank0EnableTransferComplete(CDC_ENDPOINT_OUT);
 }
 
-void Serial_::begin(uint32_t /* baud_count */)
+void Serial_::begin(unsigned long /* baudrate */)
 {
 	// uart config is ignored in USB-CDC
 }
 
-void Serial_::begin(uint32_t /* baud_count */, uint16_t /* config */)
+void Serial_::begin(unsigned long /* baudrate */, uint16_t /* config */)
 {
 	// uart config is ignored in USB-CDC
 }

--- a/cores/arduino/USB/USBAPI.h
+++ b/cores/arduino/USB/USBAPI.h
@@ -101,8 +101,8 @@ class Serial_ : public arduino::HardwareSerial, arduino::PluggableUSBModule
 {
 public:
 	Serial_(USBDeviceClass &_usb);
-	void begin(uint32_t baud_count);
-	void begin(unsigned long, uint16_t);
+	void begin(unsigned long baudrate);
+	void begin(unsigned long baudrate, uint16_t config);
 	void end(void);
 
 	virtual int available(void);


### PR DESCRIPTION
This is usually not a problem becuase we use the arm-none-eabi-gcc compiler thas has type `uint32_t` aliased to `unsigned long`. Anyway this is not mandatory in general, and the compiler may choose to alias `uint32_t` with `unsigned int` as it happens with llvm/clang.

Since we use clangd as language server on the Arduino IDE 2.0 the Serial_ object and all the derived instances (Serial, SerialUSB, ...) are not available in code-completion suggestions.