### PR TITLE
Prevent malloc from overwriting the stack

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -56,3 +56,10 @@ int main( void )
 
   return 0;
 }
+
+// Ensure our version of sbrk is used by forcing a reference to it here
+// (without this, an undefined reference only occurs later when linking
+// newlib, and the dummy from libgloss/nosys will be used instead).
+// This variable will be optimized away later.
+extern "C" void *_sbrk(int);
+void * force_reference_to_sbrk = (void*)&_sbrk;

--- a/cores/arduino/sbrk.c
+++ b/cores/arduino/sbrk.c
@@ -1,0 +1,19 @@
+#include <samd.h>
+#include <stddef.h>
+#include <errno.h>
+
+void *_sbrk(int incr)
+{
+  extern char end; /* End of global variables, defined by the linker */
+  static char *brkval = &end ;
+  char *prev_brkval = brkval;
+
+  if (brkval + incr > (char *)__get_MSP()) {
+    /* Heap and stack collision */
+    errno = ENOMEM;
+    return (void*) -1;
+  }
+
+  brkval += incr ;
+  return (void*) prev_brkval;
+}

--- a/cores/arduino/sbrk.c
+++ b/cores/arduino/sbrk.c
@@ -2,13 +2,17 @@
 #include <stddef.h>
 #include <errno.h>
 
+/* How much free space to keep between the stack and the heap by malloc.
+ * Can be changed by the application at any time. */
+size_t __malloc_margin = 64;
+
 void *_sbrk(int incr)
 {
   extern char end; /* End of global variables, defined by the linker */
   static char *brkval = &end ;
   char *prev_brkval = brkval;
 
-  if (brkval + incr > (char *)__get_MSP()) {
+  if (brkval + incr + __malloc_margin > (char *)__get_MSP()) {
     /* Heap and stack collision */
     errno = ENOMEM;
     return (void*) -1;

--- a/platform.txt
+++ b/platform.txt
@@ -39,13 +39,13 @@ compiler.optimization_flags.debug=-Og -g3
 
 compiler.path={runtime.tools.arm-none-eabi-gcc-7-2017q4.path}/bin/
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-mcpu={build.mcu} -mthumb -c -g {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -nostdlib --param max-inline-insns-single=500 -MMD
+compiler.c.flags=-mcpu={build.mcu} -mthumb -c -g {compiler.optimization_flags} {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections --param max-inline-insns-single=500 -MMD
 compiler.c.elf.cmd=arm-none-eabi-g++
 compiler.c.elf.flags={compiler.optimization_flags} -Wl,--gc-sections -save-temps
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-mcpu={build.mcu} -mthumb -c -g -x assembler-with-cpp -MMD
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-mcpu={build.mcu} -mthumb -c -g {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -fno-threadsafe-statics -nostdlib --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD
+compiler.cpp.flags=-mcpu={build.mcu} -mthumb -c -g {compiler.optimization_flags} {compiler.warning_flags} -std=gnu++11 -ffunction-sections -fdata-sections -fno-threadsafe-statics --param max-inline-insns-single=500 -fno-rtti -fno-exceptions -MMD
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=arm-none-eabi-objcopy


### PR DESCRIPTION
The current implementation of malloc (or really, the underlying `sbrk()` implementation) happily allocates any amount of memory, even when that overwrites the stack or even beyond the end of RAM. This is fixed by implementing a custom `sbrk()` function that does proper checking. The code is based on the `sbrk()` from the STM32 Arduino core, but with an additional margin added (to make it fail when it comes close to the stack, instead of just when it would actually overwrite the stack).

This margin approach is copied from avr-libc's malloc implementation. I considered also copying more of avr-libc's configurability (e.g. `__malloc_heap_start` and `__malloc_heap_end`), but that ended up just adding complexity without a very clear usecase, so I left that out.

See the d232b594d4673604d0cf360a39dfa66fdef6c4c1 commit message for much more detail on this problem and the solution.

This PR also has a somewhat unrelated commit removing the `-nostdlib` compilation option, which was in the wrong place and thus effectively unused (and also unneeded).