### PR TITLE
Remove inappropriate CP2105 VID/PID association from Tian board definition

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -664,12 +664,6 @@ mzero_bl.bootloader.file=mzero/Bootloader_D21_M0_150515.hex
 # ------------------------------
 tian.name=Arduino Tian
 tian.upload.via_ssh=true
-tian.vid.0=0x10C4
-tian.pid.0=0xEA70
-tian.descriptor.0=Enhanced Com Port
-tian.upload_port.0.vid=0x10C4
-tian.upload_port.0.pid=0xEA70
-tian.upload_port.1.board=tian
 
 tian.upload.tool=avrdude
 tian.upload.tool.default=avrdude
@@ -706,10 +700,5 @@ tian.drivers=SiliconLabs-CP2105/Silicon Labs VCP Driver.pkg
 # Arduino Tian Console port (not for upload)
 # ------------------------------------------
 tian_cons.name=Arduino Tian (MIPS Console port)
-tian_cons.vid.0=0x10C4
-tian_cons.pid.0=0xEA70
-tian_cons.upload_port.0.vid=0x10C4
-tian_cons.upload_port.0.pid=0xEA70
-tian_cons.descriptor.0=Standard Com Port
 tian_cons.hide=true
 tian_cons.build.board=SAMD_TIAN


### PR DESCRIPTION
Arduino board definitions may associate unique properties of a port:

https://arduino.github.io/arduino-cli/latest/pluggable-discovery-specification/#board-identification

https://arduino.github.io/arduino-cli/latest/platform-specification/#board-vidpid

These are used by convenience features in the Arduino development tools that identify a port as a specific Arduino board.

In the case of boards that connect to the host computer via a virtual COM port, that identifier is the USB VID/PID pair.

This association should only be done with properties that are unique to the board. For most official Arduino boards, this is possible because Arduino creates dedicated VID/PID pairs for that product. In the case of the Tian, a general purpose Silicon Labs CP2105 chip was selected as the USB interface. The board has the manufacturer supplied VID/PID pair 10C4:EA70. In this case it is irresponsible to associate that VID/PID pair with a board definition because any arbitrary device might have this VID/PID. The ports list will be confusing for users who have a CP2105 connected to their computer (whether it is on a 3rd party board or some other unrelated hardware).