### PR TITLE
Update I2S.cpp to work with RTCZero library

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -422,6 +422,7 @@ void I2SClass::enableClock(int divider)
   GCLK->GENCTRL.bit.ID = _clockGenerator;
   GCLK->GENCTRL.bit.SRC = src;
   GCLK->GENCTRL.bit.IDC = 1;
+  GCLK->GENCTRL.bit.DIVSEL = 0;
   GCLK->GENCTRL.bit.GENEN = 1;
 
   // enable


### PR DESCRIPTION
I2S.cpp configures the clock without specifying what to GLCK->DIVSEL bit. This causes issues when the bit is set to 1 by other libraries such as RTCZero. Explicitly setting this value fixes the problem. More can be found about this issue in the following thread https://github.com/arduino/ArduinoCore-samd/issues/451