### PR TITLE
Added BUFFER_LENGTH macro in Wire.h

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -24,6 +24,8 @@
 #include "variant.h"
 #include "SERCOM.h"
 
+#define BUFFER_LENGTH 256
+
  // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
 
@@ -74,10 +76,10 @@ class TwoWire : public HardwareI2C
     bool transmissionBegun;
 
     // RX Buffer
-    arduino::RingBufferN<256> rxBuffer;
+    arduino::RingBufferN<BUFFER_LENGTH> rxBuffer;
 
     //TX buffer
-    arduino::RingBufferN<256> txBuffer;
+    arduino::RingBufferN<BUFFER_LENGTH> txBuffer;
     uint8_t txAddress;
 
     // Callback user functions


### PR DESCRIPTION
Added this macro to simplify changing the buffer size 
Matching [AVR core](https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/Wire/src/Wire.h#L29) and [Arduino docs](https://support.arduino.cc/hc/en-us/articles/4406686928786-Modify-the-buffer-size-of-the-Wire-library)

Context: 

I needed to increase the rx buffer size to use the MLX90640 thermal camera.
At startup, the board retrieve the settings of the camera and this operation needed a 1664 bytes size buffer. 
Even after startup, each reading is 1536 bytes size, definitively more than the 256 default bytes size buffer.

[The BUFFER_LENGTH macro exist on AVR core](https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/Wire/src/Wire.h#L29) and simplify editing the buffer size. Furthermore there is an [official Arduino articles on it](https://support.arduino.cc/hc/en-us/articles/4406686928786-Modify-the-buffer-size-of-the-Wire-library). I think it could be a good thing to add this macro on others Arduino platforms, not only AVR.