### PR TITLE
USB CDC: Line Info Per Instance

### DIFF
--- a/cores/arduino/USB/CDC.cpp
+++ b/cores/arduino/USB/CDC.cpp
@@ -42,22 +42,6 @@ extern USBDevice_SAMD21G18x usbd;
 
 extern USBDeviceClass USBDevice;
 
-typedef struct {
-	uint32_t dwDTERate;
-	uint8_t bCharFormat;
-	uint8_t bParityType;
-	uint8_t bDataBits;
-	uint8_t lineState;
-} LineInfo;
-
-static volatile LineInfo _usbLineInfo = {
-	115200, // dWDTERate
-	0x00,   // bCharFormat
-	0x00,   // bParityType
-	0x08,   // bDataBits
-	0x00    // lineState
-};
-
 static volatile int32_t breakValue = -1;
 
 // CDC

--- a/cores/arduino/USB/CDC.h
+++ b/cores/arduino/USB/CDC.h
@@ -73,6 +73,14 @@ typedef struct
 	EndpointDescriptor			out;
 } CDCDescriptor;
 
+typedef struct {
+	uint32_t dwDTERate;
+	uint8_t bCharFormat;
+	uint8_t bParityType;
+	uint8_t bDataBits;
+	uint8_t lineState;
+} LineInfo;
+
 
 #endif
 #endif

--- a/cores/arduino/USB/USBAPI.h
+++ b/cores/arduino/USB/USBAPI.h
@@ -176,6 +176,14 @@ private:
 	bool stalled;
 	unsigned int epType[3];
 
+	volatile LineInfo _usbLineInfo = {
+		115200, // dWDTERate
+		0x00,   // bCharFormat
+		0x00,   // bParityType
+		0x08,   // bDataBits
+		0x00    // lineState
+	};
+
 };
 extern Serial_ SerialUSB;
 


### PR DESCRIPTION
This PR moves the USB line info from being a static variable inside the `Serial_` class.

Reasoning is that the SAMD chips have enough USB endpoints to allow a second CDC interface. However the current implementation causes both interfaces to share the line info. 

Use-Case: 
In my current project a MKR Zero is among other things used to act as a Serial-to-USB bridge for two connected serial devices. 
The USB host application should be able to change some of the things stored in line info (mainly baudrate, parity and DTR). 
These are read from the respective `Serial_` object and (on change) are changed on the hardware `Serial` connected to the external device.
Without this change it's not possible to have both serial interfaces running on different baudrates etc. Changing it on one of them will change it in both.

I've been using this change for a bit and couldn't notice any issues with this change.