### PR TITLE
Remove eAnalogReference from ArduinoCore-samd

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -73,18 +73,6 @@ extern "C"{
 #ifdef __cplusplus
 extern "C" {
 #endif
-/*
- * \brief SAMD products have only one reference for ADC
- */
-typedef enum _eAnalogReference
-{
-  AR_DEFAULT,
-  AR_INTERNAL,
-  AR_EXTERNAL,
-  AR_INTERNAL1V0,
-  AR_INTERNAL1V65,
-  AR_INTERNAL2V23
-} eAnalogReference ;
 
 /*
  * \brief Set the resolution of analogRead return values. Default is 10 bits (range from 0 to 1023).

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -91,7 +91,7 @@ static inline uint32_t mapResolution(uint32_t value, uint32_t from, uint32_t to)
  *
  * Warning : On Arduino Zero board the input/output voltage for SAMD21G18 is 3.3 volts maximum
  */
-void analogReference(eAnalogReference mode)
+void analogReference(AnalogReference mode)
 {
   syncADC();
   switch (mode)


### PR DESCRIPTION
Currently, the header for `analogReference(...)` is defined in ArduinoCore-API ([api/Common.h](https://github.com/arduino/ArduinoCore-API/blob/master/api/Common.h#L100)).

My proposal is to move this enum to ArduinoCore-API and align the naming to the scheme that is used there. 

This comes with the additional benefit of fixing a bug where the header that is defined over at `ArduinoCore-API` takes `uint8_t` as argument type, which leads to a compilation warning when compiling together with `ArduinoCore-samd`.

I filed a corresponding PR there too:
https://github.com/arduino/ArduinoCore-API/pull/236

This unfortunately breaks a lot of the sketches as the corresponding change has not yet landed in ArduinoCore-API.